### PR TITLE
feat: compact detailed list rows and separate overdue/late section

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -228,9 +228,21 @@
 
     /* --- TABLE (DETAILED LIST) --- */
     .details-table { width: 100%; border-collapse: collapse; text-align: left; }
-    .details-table th, .details-table td { 
-      padding: var(--s2, 1rem) var(--s3, 1.5rem); 
-      border-bottom: 1px solid var(--divider-color, #333); 
+    .details-table th, .details-table td {
+      padding: 0.4rem var(--s2, 1rem);
+      border-bottom: 1px solid var(--divider-color, #333);
+    }
+    .overdue-section-header {
+      padding: 0.5rem var(--s2, 1rem);
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      color: var(--text-color-muted, #9e9e9e);
+      border-top: 1px solid var(--divider-color, #333);
+      border-bottom: 1px solid var(--divider-color, #333);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
     }
     .details-table th { 
       background: var(--card-bg, #1e1e1e); 
@@ -411,6 +423,24 @@
             <!-- Rows injected by JS -->
           </tbody>
         </table>
+        <div id="overdue-section" class="hidden">
+          <div class="overdue-section-header">
+            OVERDUE &amp; LATE
+            <span id="overdue-section-count" class="badge badge-red"></span>
+          </div>
+          <table class="details-table">
+            <thead>
+              <tr>
+                <th>Due Date</th>
+                <th>Project</th>
+                <th>Task</th>
+                <th>Time Spent</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody id="overdue-table-body"></tbody>
+          </table>
+        </div>
       </div>
 
     </div>
@@ -589,6 +619,7 @@
       updateBarChart();
       updatePieChart();
       renderTable(sortedEntries);
+      renderOverdueSection(metrics.overdueEntries);
       updateSortIndicators();
     };
 
@@ -773,6 +804,32 @@
       `).join('');
     };
 
+    const renderOverdueSection = (entries) => {
+      const section = document.getElementById('overdue-section');
+      const tbody = document.getElementById('overdue-table-body');
+      const countBadge = document.getElementById('overdue-section-count');
+      if (entries.length === 0) {
+        section.classList.add('hidden');
+        return;
+      }
+      section.classList.remove('hidden');
+      countBadge.textContent = entries.length;
+      tbody.innerHTML = entries.map(entry => `
+        <tr>
+          <td style="white-space: nowrap;">${entry.date ? formatDateShort(entry.date) : '—'}</td>
+          <td style="color: var(--text-color-muted, #9e9e9e); font-size: 0.875rem;">${entry.projectName}</td>
+          <td style="font-weight: 500;">${entry.taskTitle}</td>
+          <td class="time-cell">${formatTime(entry.timeSpent)}</td>
+          <td>
+            ${entry.late
+              ? `<span class="badge badge-yellow">Late</span>`
+              : `<span class="badge badge-red">Overdue</span>`
+            }
+          </td>
+        </tr>
+      `).join('');
+    };
+
     // helper for normalizing a task's dueDay to day boundaries (UTC)
     const getDueBounds = (task) => {
       let dueStart = null;
@@ -842,7 +899,8 @@
         projectCompletedData: {},
         projectOverdueData: {},
         projectLateData: {},
-        tableEntries: []
+        tableEntries: [],
+        overdueEntries: []
       };
 
       const now = Date.now();
@@ -953,11 +1011,11 @@
           }
         }
         
-        // add a row for overdue or late tasks that had no time entries
+        // add a row for overdue or late tasks that had no time entries — goes to separate section
         if (taskTimeInRange === 0 && (isOverdue || isLate)) {
           const badge = isLate ? 'Late' : 'Overdue';
           const dateStr = dueStart ? toLocalDate(new Date(dueStart)) : '';
-          metrics.tableEntries.push({
+          metrics.overdueEntries.push({
             date: dateStr,
             projectName: pName,
             taskTitle: `${task.title || 'Untitled Task'} (${badge})`,
@@ -1042,6 +1100,7 @@
     window.updateBarChart = updateBarChart;
     window.updatePieChart = updatePieChart;
     window.sortEntries = sortEntries;
+    window.renderOverdueSection = renderOverdueSection;
 
     // --- SP INTEGRATION / NATIVE IFRAME COMMS ---
     const pullDataFromSP = async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -129,8 +129,8 @@ describe('Date Range Reporter UI', () => {
       };
       window.processData([task], []);
       expect(document.getElementById('stat-overdue').innerText).toBe('1');
-      // table should include this task despite zero time
-      const row = document.querySelector('#details-table-body tr');
+      // overdue task with no time goes to the separate overdue section
+      const row = document.querySelector('#overdue-table-body tr');
       expect(row.textContent).toContain('Initial Overdue');
     });
 
@@ -194,8 +194,8 @@ describe('Date Range Reporter UI', () => {
       window.processData([task], []);
       expect(document.getElementById('stat-overdue').innerText).toBe('1');
       expect(document.getElementById('stat-late').innerText).toBe('1');
-      // table should include the task despite zero time
-      const row = document.querySelector('#details-table-body tr');
+      // late task with no time goes to the separate overdue section
+      const row = document.querySelector('#overdue-table-body tr');
       expect(row.textContent).toContain('Done Late');
     });
 
@@ -388,13 +388,13 @@ describe('Date Range Reporter UI', () => {
       const lateTask = { id:'t2', parentId:null, title:'Bar', isDone:true, doneOn: now, dueDay: yesterdayStr, timeSpentOnDay:{} };
       window.processData([overdueTask, lateTask], []);
 
-
-      // verify list badges
-      const rows = document.querySelectorAll('#details-table-body tr');
-      expect(rows.length).toBe(2);
-      const text = Array.from(rows).map(r => r.textContent).join(' ');
+      // verify overdue/late rows appear in the separate overdue section, not the main table
+      const overdueRows = document.querySelectorAll('#overdue-table-body tr');
+      expect(overdueRows.length).toBe(2);
+      const text = Array.from(overdueRows).map(r => r.textContent).join(' ');
       expect(text).toContain('Overdue');
       expect(text).toContain('Late');
+      expect(document.getElementById('overdue-section').classList.contains('hidden')).toBe(false);
 
       const barSelect = document.getElementById('bar-chart-select');
       const pieSelect = document.getElementById('pie-chart-select');
@@ -431,10 +431,51 @@ describe('Date Range Reporter UI', () => {
       expect(pieLegend.querySelector('.legend-item')).not.toBeNull();
     });
 
+    it('overdue/late tasks with no time entries should appear in overdue section, not the main table', () => {
+      // Period = today; overdue task due in the past, late task done after due date
+      const preset = document.getElementById('date-preset');
+      preset.value = 'today';
+      preset.dispatchEvent(new Event('change'));
+
+      const now = Date.now();
+      const pastDate = '2026-01-15';
+      const overdueTask = { id:'o1', parentId:null, title:'Overdue Thing', isDone:false, dueDay: pastDate, timeSpentOnDay:{} };
+      const lateTask = { id:'l1', parentId:null, title:'Late Thing', isDone:true, doneOn: now, dueDay: pastDate, timeSpentOnDay:{} };
+      window.processData([overdueTask, lateTask], []);
+
+      // main table should have no rows for these tasks
+      const mainRows = document.querySelectorAll('#details-table-body tr');
+      const mainText = Array.from(mainRows).map(r => r.textContent).join(' ');
+      expect(mainText).not.toContain('Overdue Thing');
+      expect(mainText).not.toContain('Late Thing');
+
+      // overdue section should show both
+      expect(document.getElementById('overdue-section').classList.contains('hidden')).toBe(false);
+      const overdueRows = document.querySelectorAll('#overdue-table-body tr');
+      expect(overdueRows.length).toBe(2);
+      const overdueText = Array.from(overdueRows).map(r => r.textContent).join(' ');
+      expect(overdueText).toContain('Overdue Thing');
+      expect(overdueText).toContain('Late Thing');
+    });
+
+    it('overdue section should be hidden when there are no overdue or late tasks', () => {
+      const task = { id:'t1', parentId:null, title:'Normal Task', isDone:false, dueDay:null, timeSpentOnDay:{} };
+      window.processData([task], []);
+      expect(document.getElementById('overdue-section').classList.contains('hidden')).toBe(true);
+    });
+
     it('detail list columns are sortable when headers are clicked', () => {
+      // use custom range so time entries fall within the period (tasks go to main table, not overdue section)
+      // set values directly without dispatching change to avoid double processData call (double sort-handler binding)
+      const preset = document.getElementById('date-preset');
+      preset.value = 'custom';
+      document.getElementById('custom-date-container').classList.remove('hidden');
+      document.getElementById('date-from').value = '2026-01-01';
+      document.getElementById('date-to').value = '2026-01-02';
+
       // create two tasks with different dates
-      const taskA = { id:'a', parentId:null, title:'A', isDone:false, dueDay:'2026-01-01', timeSpentOnDay:{'2026-01-01':3600000} };
-      const taskB = { id:'b', parentId:null, title:'B', isDone:false, dueDay:'2026-01-02', timeSpentOnDay:{'2026-01-02':3600000} };
+      const taskA = { id:'a', parentId:null, title:'A', isDone:true, doneOn: new Date('2026-01-01').getTime(), dueDay:'2026-01-01', timeSpentOnDay:{'2026-01-01':3600000} };
+      const taskB = { id:'b', parentId:null, title:'B', isDone:true, doneOn: new Date('2026-01-02').getTime(), dueDay:'2026-01-02', timeSpentOnDay:{'2026-01-02':3600000} };
       window.processData([taskA, taskB], []);
       // capture initial order of date cells
       const initial = Array.from(document.querySelectorAll('#details-table-body tr td:first-child')).map(td => td.textContent);


### PR DESCRIPTION
## Summary
- Compact the Detailed List table rows (reduced padding from `1rem 1.5rem` → `0.4rem 1rem`)
- Move overdue/late tasks with no time entries out of the main table into a dedicated **OVERDUE & LATE** section below it, with a count badge
- The overdue section is hidden when there are no overdue/late tasks
- The main table now strictly shows time-logged entries for the selected period

## Test plan
- [ ] Open Detailed List with Period = Today — time entries appear in the main table, overdue items from past days appear only in the OVERDUE & LATE section
- [ ] Switch periods — overdue section updates with all currently overdue/late tasks regardless of period
- [ ] No overdue tasks → overdue section is hidden
- [ ] `npm test` passes (25 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)