### PR TITLE
feat: context-aware bar labels and calendar-month date ranges

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -738,33 +738,58 @@
         lbl.textContent = yTickFn(i * yStep * unitSize);
         parentEl.appendChild(lbl);
       });
-      // adjust bars for preset: monthly/yearly should cap at 12
-      let maxBars = 30;
+      const DAY_NAMES   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
       const preset = document.getElementById('date-preset').value;
-      if (preset === 'year' || preset === 'month') {
-        maxBars = 12;
-      }
-      let step = Math.ceil(chartData.data.length / maxBars);
-      for (let i = 0; i < chartData.data.length; i += step) {
-        let chunkSum = 0;
-        let chunkCount = 0;
-        for (let j = 0; j < step && i + j < chartData.data.length; j++) {
-          chunkSum += chartData.data[i+j];
-          chunkCount++;
-        }
-        
-        const val = step === 1 ? chunkSum : chunkSum / chunkCount;
-        const label = chartData.labels[i].substring(5);
+
+      const appendBar = (val, label, titleDate) => {
         const heightPx = (val / scaleMax) * BAR_AREA;
         const displayVal = formatFn(val);
-
         const col = document.createElement('div');
         col.className = 'bar-col';
         col.innerHTML = `
           <div class="bar" style="height: ${heightPx}px; background: ${color};" data-val="${displayVal}"></div>
-          <div class="bar-label" title="${chartData.labels[i]}">${label}</div>
+          <div class="bar-label" title="${titleDate}">${label}</div>
         `;
         container.appendChild(col);
+      };
+
+      if (preset === 'year') {
+        // Group daily data into calendar months
+        const monthBuckets = new Map();
+        for (let i = 0; i < chartData.labels.length; i++) {
+          const key = chartData.labels[i].substring(0, 7); // "YYYY-MM"
+          monthBuckets.set(key, (monthBuckets.get(key) || 0) + chartData.data[i]);
+        }
+        for (const [key, sum] of monthBuckets) {
+          const monthIdx = parseInt(key.substring(5), 10) - 1;
+          appendBar(sum, MONTH_NAMES[monthIdx], key + '-01');
+        }
+      } else {
+        let step = 1;
+        if (preset === 'month') {
+          step = 7;
+        } else if (preset === 'custom') {
+          step = Math.max(1, Math.ceil(chartData.data.length / 30));
+        }
+
+        for (let i = 0; i < chartData.data.length; i += step) {
+          let chunkSum = 0;
+          for (let j = 0; j < step && i + j < chartData.data.length; j++) {
+            chunkSum += chartData.data[i + j];
+          }
+          const dateStr = chartData.labels[i];
+          const d = new Date(dateStr + 'T00:00:00');
+          let label;
+          if (preset === 'this-week' || preset === 'week' || preset === 'from-weekday') {
+            label = DAY_NAMES[d.getDay()];
+          } else if (preset === 'month') {
+            label = MONTH_NAMES[d.getMonth()] + ' ' + d.getDate();
+          } else {
+            label = dateStr.substring(5); // custom: MM-DD
+          }
+          appendBar(chunkSum, label, dateStr);
+        }
       }
       
       // Setup tooltip listeners for bars
@@ -922,12 +947,12 @@
         } else if (preset === 'week') {
           startObj.setDate(endObj.getDate() - 6);
         } else if (preset === 'month') {
-          startObj.setMonth(endObj.getMonth() - 1);
-          if (startObj.getDate() !== endObj.getDate()) {
-            startObj.setDate(0); // rewind to last day of previous month
-          }
+          startObj.setDate(1);
+          startObj.setMonth(startObj.getMonth() - 1); // 1st of last month
+          endObj.setDate(0);                           // last day of last month
         } else if (preset === 'year') {
-          startObj.setFullYear(endObj.getFullYear() - 1);
+          startObj.setDate(1);
+          startObj.setMonth(startObj.getMonth() - 11); // 1st of 11 months ago → 12 calendar months
         } else if (preset === 'from-weekday') {
           const targetDay = parseInt(document.getElementById('weekday-select').value, 10);
           const daysBack = (endObj.getDay() - targetDay + 7) % 7;

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -294,6 +294,19 @@
             <option value="month">Past Month</option>
             <option value="year">Past Year</option>
             <option value="custom">Custom Range...</option>
+            <option value="from-weekday">Starting from weekday</option>
+          </select>
+        </div>
+        <div id="weekday-picker-container" class="control-box hidden">
+          <label for="weekday-select">Weekday</label>
+          <select id="weekday-select">
+            <option value="1">Monday</option>
+            <option value="2">Tuesday</option>
+            <option value="3">Wednesday</option>
+            <option value="4">Thursday</option>
+            <option value="5">Friday</option>
+            <option value="6">Saturday</option>
+            <option value="0">Sunday</option>
           </select>
         </div>
       </div>
@@ -562,20 +575,62 @@
 
     const presetSelect = document.getElementById('date-preset');
     const customContainer = document.getElementById('custom-date-container');
+    const weekdayPickerContainer = document.getElementById('weekday-picker-container');
+    const weekdaySelect = document.getElementById('weekday-select');
+    const dateFromInput = document.getElementById('date-from');
+    const dateToInput = document.getElementById('date-to');
+    const barChartSelect = document.getElementById('bar-chart-select');
+    const pieChartSelect = document.getElementById('pie-chart-select');
 
     presetSelect.addEventListener('change', (e) => {
-      if (e.target.value === 'custom') {
-        customContainer.classList.remove('hidden');
-      } else {
-        customContainer.classList.add('hidden');
-      }
+      customContainer.classList.toggle('hidden', e.target.value !== 'custom');
+      weekdayPickerContainer.classList.toggle('hidden', e.target.value !== 'from-weekday');
+      localStorage.setItem('sp-dashboard-date-preset', e.target.value);
       processData(cachedTasks, cachedProjects);
     });
 
-    document.getElementById('date-from').addEventListener('change', () => processData(cachedTasks, cachedProjects));
-    document.getElementById('date-to').addEventListener('change', () => processData(cachedTasks, cachedProjects));
-    document.getElementById('bar-chart-select').addEventListener('change', () => updateBarChart());
-    document.getElementById('pie-chart-select').addEventListener('change', () => updatePieChart());
+    dateFromInput.addEventListener('change', () => {
+      localStorage.setItem('sp-dashboard-date-from', dateFromInput.value);
+      processData(cachedTasks, cachedProjects);
+    });
+    dateToInput.addEventListener('change', () => {
+      localStorage.setItem('sp-dashboard-date-to', dateToInput.value);
+      processData(cachedTasks, cachedProjects);
+    });
+    weekdaySelect.addEventListener('change', () => {
+      localStorage.setItem('sp-dashboard-weekday-select', weekdaySelect.value);
+      processData(cachedTasks, cachedProjects);
+    });
+    barChartSelect.addEventListener('change', () => {
+      localStorage.setItem('sp-dashboard-bar-chart-select', barChartSelect.value);
+      updateBarChart();
+    });
+    pieChartSelect.addEventListener('change', () => {
+      localStorage.setItem('sp-dashboard-pie-chart-select', pieChartSelect.value);
+      updatePieChart();
+    });
+
+    // Restore persisted selections
+    const savedPreset = localStorage.getItem('sp-dashboard-date-preset');
+    if (savedPreset) {
+      presetSelect.value = savedPreset;
+      customContainer.classList.toggle('hidden', savedPreset !== 'custom');
+      weekdayPickerContainer.classList.toggle('hidden', savedPreset !== 'from-weekday');
+      if (savedPreset === 'custom') {
+        const savedFrom = localStorage.getItem('sp-dashboard-date-from');
+        const savedTo = localStorage.getItem('sp-dashboard-date-to');
+        if (savedFrom) dateFromInput.value = savedFrom;
+        if (savedTo) dateToInput.value = savedTo;
+      }
+      if (savedPreset === 'from-weekday') {
+        const savedWeekday = localStorage.getItem('sp-dashboard-weekday-select');
+        if (savedWeekday) weekdaySelect.value = savedWeekday;
+      }
+    }
+    const savedBar = localStorage.getItem('sp-dashboard-bar-chart-select');
+    const savedPie = localStorage.getItem('sp-dashboard-pie-chart-select');
+    if (savedBar) barChartSelect.value = savedBar;
+    if (savedPie) pieChartSelect.value = savedPie;
 
     // --- RENDER LOGIC ---
     const updateDashboardUI = (metrics) => {
@@ -873,6 +928,10 @@
           }
         } else if (preset === 'year') {
           startObj.setFullYear(endObj.getFullYear() - 1);
+        } else if (preset === 'from-weekday') {
+          const targetDay = parseInt(document.getElementById('weekday-select').value, 10);
+          const daysBack = (endObj.getDay() - targetDay + 7) % 7;
+          startObj.setDate(endObj.getDate() - daysBack);
         }
         dateFromStr = toLocalDate(startObj);
         dateToStr = toLocalDate(endObj);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -491,5 +491,29 @@ describe('Date Range Reporter UI', () => {
       dateTh.click();
       expect(dateTh.classList.contains('sorted-desc')).toBe(true);
     });
+
+    it('from-weekday preset shows weekday picker and produces correct date range', () => {
+      const presetSelect = document.getElementById('date-preset');
+      const weekdaySelect = document.getElementById('weekday-select');
+      const weekdayPickerContainer = document.getElementById('weekday-picker-container');
+      const barContainer = document.getElementById('bar-chart-container');
+
+      presetSelect.value = 'from-weekday';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(weekdayPickerContainer.classList.contains('hidden')).toBe(false);
+
+      const today = new Date();
+      for (const targetDay of [0, 1, 2, 3, 4, 5, 6]) {
+        weekdaySelect.value = String(targetDay);
+        weekdaySelect.dispatchEvent(new Event('change'));
+        window.processData([], []);
+        const daysBack = (today.getDay() - targetDay + 7) % 7;
+        expect(barContainer.querySelectorAll('.bar-col').length).toBe(daysBack + 1);
+      }
+
+      presetSelect.value = 'today';
+      presetSelect.dispatchEvent(new Event('change'));
+      expect(weekdayPickerContainer.classList.contains('hidden')).toBe(true);
+    });
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,8 @@ describe('Date Range Reporter UI', () => {
   let scriptContent;
 
   beforeEach(() => {
-    // Reset the DOM
+    // Reset the DOM and clear any persisted localStorage state between tests
+    localStorage.clear();
     document.documentElement.innerHTML = html;
 
     // In a JSDOM environment, we need to manually execute the script 
@@ -65,8 +66,8 @@ describe('Date Range Reporter UI', () => {
       expect(toLocalDate(new Date(dueStart))).toBe('2026-02-20');
     });
 
-    it('month preset should not roll over when today is the 31st', () => {
-      // March 31, 2026 at noon — without the fix, setMonth(Feb) on Mar 31 rolls to Mar 3
+    it('month preset should cover the full previous calendar month', () => {
+      // March 31, 2026 at noon — month preset should show Feb 1–28 (full previous calendar month)
       vi.useFakeTimers({ now: new Date('2026-03-31T12:00:00').getTime() });
       const consoleSpy = vi.spyOn(console, 'log');
       const presetSelect = document.getElementById('date-preset');
@@ -76,8 +77,8 @@ describe('Date Range Reporter UI', () => {
       vi.useRealTimers();
       const rangeLog = consoleSpy.mock.calls.find(args => String(args[0]).includes('computed date range'));
       expect(rangeLog).toBeDefined();
-      expect(rangeLog[1]).toBe('2026-02-28'); // should be Feb 28, not Mar 3
-      expect(rangeLog[2]).toBe('2026-03-31');
+      expect(rangeLog[1]).toBe('2026-02-01'); // 1st of previous calendar month
+      expect(rangeLog[2]).toBe('2026-02-28'); // last day of previous calendar month
       consoleSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## Summary

- **Week presets** (This Week, Past Week, Starting from weekday) now show day names (Mon, Tue, …) under Daily Trends bars instead of MM-DD dates
- **Past Month** shows 5 weekly bars labeled "May 1", "May 8", etc., covering the full previous calendar month (1st → last day) instead of a rolling 30-day window
- **Past Year** shows 12 true calendar-month bars labeled Jan–Dec, each grouped from the 1st to the last day of that month — previously used arbitrary ~31-day chunks that didn't align to month boundaries
- Multi-day buckets now sum values (total time/tasks per period) instead of averaging them
- Fix `localStorage` leak between tests by clearing it in `beforeEach`

## Test plan

- [ ] `npm test` passes (26 tests)
- [ ] `npm run check:syntax` passes
- [ ] This Week / Past Week / Starting from weekday → day-name bar labels
- [ ] Past Month → weekly bars labeled "May 1", "May 8", "May 15", "May 22", "May 29"
- [ ] Past Year → 12 bars labeled Jul → Jun with correct monthly totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)