### PR TITLE
feat: refresh charts every 30s and include in-progress session time

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -507,6 +507,7 @@
     let cachedProjects = [];
     let latestMetrics = null;
     let currentSort = { key: 'date', dir: 'desc' }; // sorting state for details table
+    let liveUpdateInterval = null;
 
     // helper to sort table entries by given field/key
     const sortEntries = (entries, key, dir) => {
@@ -1110,6 +1111,17 @@
           });
         }
 
+        // Add in-progress session time (not yet committed to timeSpentOnDay)
+        if ((task.currentSessionTime || 0) > 0) {
+          const today = toLocalDate(new Date());
+          if (dateRange.includes(today)) {
+            const idx = dateRange.indexOf(today);
+            const cs = task.currentSessionTime;
+            metrics.weeklyData.data[idx] += cs;
+            taskTimeInRange += cs;
+          }
+        }
+
         // Tally Project Time and Total Tasks if active in window
         if (taskTimeInRange > 0) {
           metrics.totalTimeSpent += taskTimeInRange;
@@ -1249,6 +1261,7 @@
       console.log("[sp-dashboard] bootstrap timeout fired; PluginAPI exists?", !!window.PluginAPI);
       if (window.PluginAPI) {
         pullDataFromSP();
+        liveUpdateInterval = setInterval(pullDataFromSP, 30000);
       } else {
         console.log("[sp-dashboard] No PluginAPI detected. Loading mock data...");
         
@@ -1272,7 +1285,8 @@
           },
           {
             id: "t2", parentId: null, title: "General Admin", isDone: false, projectId: null,
-            timeSpentOnDay: { [dates[0]]: 3600000 /* 1h */ }
+            timeSpentOnDay: { [dates[0]]: 3600000 /* 1h */ },
+            currentSessionTime: 1800000 /* 30m in-progress session */
           },
           {
             id: "t3", parentId: null, title: "Draft Email Copy", isDone: true, doneOn: new Date('2026-02-20T10:00Z').getTime(), projectId: "p2",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -271,6 +271,35 @@ describe('Date Range Reporter UI', () => {
       expect(document.getElementById('stat-tasks').innerText).toBe('0');
     });
 
+    it('should include currentSessionTime in totalTimeSpent and bar chart when today is in range', () => {
+      const todayStr = toLocalDate(new Date());
+      const activeTask = {
+        id: 't-active',
+        parentId: null,
+        title: 'Active Task',
+        isDone: false,
+        timeSpentOnDay: { [todayStr]: 3600000 /* 1h committed */ },
+        currentSessionTime: 1800000 /* 30m in-progress */
+      };
+      window.processData([activeTask], []);
+      // stat-time should reflect 1.5h total (committed + in-progress)
+      expect(document.getElementById('stat-time').innerText).toBe('1h 30m');
+    });
+
+    it('should include currentSessionTime even when no committed time for today', () => {
+      const todayStr = toLocalDate(new Date());
+      const activeTask = {
+        id: 't-active-only',
+        parentId: null,
+        title: 'Just Started',
+        isDone: false,
+        timeSpentOnDay: {},
+        currentSessionTime: 900000 /* 15m in-progress */
+      };
+      window.processData([activeTask], []);
+      expect(document.getElementById('stat-time').innerText).toBe('0h 15m');
+    });
+
     it('should deduplicate tasks that appear in both active and archived lists', () => {
       const now = Date.now();
       const doneTask = {


### PR DESCRIPTION
## Summary

- Adds a 30-second polling interval (via `setInterval`) that re-fetches SP data whenever the plugin is running, keeping the bar chart, pie chart, and Total Time Tracked stat current during an active tracking session
- Folds `currentSessionTime` (uncommitted in-progress session time) into today's metrics when the field is present in the API response — without affecting the zero-time checks used for overdue/late entries
- Updates mock data to include a task with `currentSessionTime` so the feature is visible in standalone mode

## Test plan

- [ ] `npm test` passes (28 tests)
- [ ] Open `sp-dashboard/index.html` standalone — "General Admin" shows 1h 30m (1h committed + 30m in-progress)
- [ ] Load plugin in SP, start tracking a task, observe charts updating every ~30 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)