### PR TITLE
fix: stop double-counting parent task time against its subtasks

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -1333,7 +1333,10 @@
           const dayEnd = dayEndObj.getTime() - 1;
 
           // Time Spent Logging
-          const spentOnDate = task.timeSpentOnDay && task.timeSpentOnDay[dateStr];
+          // Skip subtasks: a parent's timeSpentOnDay already includes its subtasks'
+          // rolled-up time, so summing both double-counts (matches SP's own
+          // getTimeWorkedForDayForAllNonArchiveTasks$, which filters out subtasks).
+          const spentOnDate = !task.parentId && task.timeSpentOnDay && task.timeSpentOnDay[dateStr];
           if (spentOnDate) {
             metrics.weeklyData.data[index] += spentOnDate;
             taskTimeInRange += spentOnDate;
@@ -1409,7 +1412,7 @@
         }
 
         // Add in-progress session time (not yet committed to timeSpentOnDay)
-        if ((task.currentSessionTime || 0) > 0) {
+        if (!task.parentId && (task.currentSessionTime || 0) > 0) {
           const today = toLocalDate(new Date());
           if (dateRange.includes(today)) {
             const idx = dateRange.indexOf(today);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -441,6 +441,34 @@ describe('Date Range Reporter UI', () => {
       expect(barContainer.querySelectorAll('.bar-col').length).toBe(1);
     });
 
+    it('should not double-count a parent task and its subtasks for the same day', () => {
+      const presetSelect = document.getElementById('date-preset');
+      presetSelect.value = 'today';
+      presetSelect.dispatchEvent(new Event('change'));
+
+      const todayStr = toLocalDate(new Date());
+
+      // Parent's timeSpentOnDay already reflects the rolled-up total of its subtasks,
+      // mirroring how Super Productivity actually stores task time.
+      const parent = {
+        id: 'parent1', parentId: null, title: 'Update Reports', isDone: true, doneOn: Date.now(),
+        timeSpentOnDay: { [todayStr]: 7980000 } // 2h 13m
+      };
+      const sub1 = {
+        id: 'sub1', parentId: 'parent1', title: 'Add requests', isDone: true, doneOn: Date.now(),
+        timeSpentOnDay: { [todayStr]: 5160000 } // 1h 26m
+      };
+      const sub2 = {
+        id: 'sub2', parentId: 'parent1', title: 'Write remediations', isDone: true, doneOn: Date.now(),
+        timeSpentOnDay: { [todayStr]: 2820000 } // 47m
+      };
+
+      window.processData([parent, sub1, sub2], []);
+
+      // Total should equal the parent's rolled-up value, not parent + subtasks.
+      expect(document.getElementById('stat-time').innerText).toBe('2h 13m');
+    });
+
     it('this-week preset should include Monday through today and exclude last Sunday', () => {
       const presetSelect = document.getElementById('date-preset');
       presetSelect.value = 'this-week';


### PR DESCRIPTION
## Summary
- `processData()` summed `timeSpentOnDay` for every task returned by the plugin API, including both a parent task and its subtasks. In Super Productivity, a parent task's own `timeSpentOnDay` already includes the rolled-up time of its subtasks, so summing both double-counted any task tree with subtasks.
- Super Productivity's own worklog totals explicitly guard against this (`tasks.filter((task) => task && !task.parentId)` in `getTimeWorkedForDayForAllNonArchiveTasks$`) — this PR applies the same filter to the dashboard's time-spent aggregation and to the (currently inert) `currentSessionTime` addition, for consistency.
- Task-completion/overdue counts are unaffected — subtasks still correctly count toward those metrics.

## Test plan
- [x] Added a regression test reproducing the exact reported scenario (parent task with rolled-up time + subtasks with individual portions for the same day) — asserts the total equals the parent's value, not parent + subtasks.
- [x] `npm test` — all 40 tests pass.
- [x] `npm run check:syntax` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)