### PR TITLE
fix: verify postMessage sender before saving dashboard downloads

### DIFF
--- a/sp-dashboard/plugin.js
+++ b/sp-dashboard/plugin.js
@@ -16,6 +16,10 @@ console.log("[sp-dashboard plugin] Date Range Reporter plugin loaded!");
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (!data || data.type !== 'SP_DASHBOARD_DOWNLOAD' || !data.blob) return;
+  const isOwnIframe = Array.from(document.querySelectorAll('iframe')).some(
+    (iframe) => iframe.src && iframe.src.includes('index.html') && iframe.contentWindow === event.source
+  );
+  if (!isOwnIframe) return;
   try {
     const url = URL.createObjectURL(data.blob);
     const a = document.createElement('a');


### PR DESCRIPTION
## What

`plugin.js` (host context) saves whatever blob a `SP_DASHBOARD_DOWNLOAD` postMessage carries, but only validated the message shape (`type` + `blob`), not the sender. Any other frame present in the host page could forge that message and get an arbitrary blob written to disk via the plugin's normal download flow.

Now checks `event.source` against the plugin's own `index.html` iframe (found via `iframe.contentWindow`) before acting on the message.

## Why

Flagged by a super-productivity maintainer during review of super-productivity/super-productivity#9090 (pointing the community registry at this fork): low severity since it needs another frame already inside the host app, but a cheap hardening fix.

## Testing

Verified live in a real browser (Puppeteer), not just unit tests:
- Built a harness matching the real host/iframe relationship: host page running `plugin.js`, the real `index.html` in one iframe, plus a rogue iframe simulating another frame in the host page.
- Legit flow: clicking Share → Download PNG in the real UI still saves the PNG, on both old and new `plugin.js`.
- Exploit flow: rogue iframe forging `SP_DASHBOARD_DOWNLOAD` got its file saved under the **old** `plugin.js` (proving the gap was real/reachable), and was silently ignored under the **new** code.
- `npm test` — all 49 existing tests pass unchanged.