### PR TITLE
fix: correctly identify this plugin's own iframe (regression hotfix)

### DIFF
--- a/sp-dashboard/plugin.js
+++ b/sp-dashboard/plugin.js
@@ -10,16 +10,32 @@
 
 console.log("[sp-dashboard plugin] Date Range Reporter plugin loaded!");
 
+// Must match the "id" field in manifest.json.template.
+const PLUGIN_ID = 'sp-dashboard';
+
+// Super Productivity loads every plugin's view via `iframe.srcdoc` (no `src` URL),
+// and marks the iframe's owner with `data-plugin-id`. Since the iframe carries
+// `allow-same-origin`, we can read `frameElement` off the sender's Window to find
+// the exact DOM element that sent a message and check its owning plugin id --
+// this is what actually distinguishes our iframe from any other installed
+// plugin's, unlike matching on `src` (which is always empty under `srcdoc`).
+function isOwnPluginWindow(win) {
+  if (!win) return false;
+  try {
+    const el = win.frameElement;
+    return !!el && el.getAttribute('data-plugin-id') === PLUGIN_ID;
+  } catch (e) {
+    return false;
+  }
+}
+
 // The dashboard iframe is sandboxed and typically cannot start a file download itself.
 // It posts the generated image here; we save it from the (unsandboxed) host context,
 // which uses the app's normal download flow (defaults to the user's Downloads folder).
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (!data || data.type !== 'SP_DASHBOARD_DOWNLOAD' || !data.blob) return;
-  const isOwnIframe = Array.from(document.querySelectorAll('iframe')).some(
-    (iframe) => iframe.src && iframe.src.includes('index.html') && iframe.contentWindow === event.source
-  );
-  if (!isOwnIframe) return;
+  if (!isOwnPluginWindow(event.source)) return;
   try {
     const url = URL.createObjectURL(data.blob);
     const a = document.createElement('a');
@@ -39,7 +55,7 @@ window.addEventListener('message', (event) => {
 // Whenever the user adds a task, tracks time, or changes a project, this fires.
 PluginAPI.registerHook(PluginAPI.Hooks.ACTION, async (action) => {
   console.log("[sp-dashboard plugin] ACTION hook triggered", action.type);
-  const iframes = document.querySelectorAll('iframe');
+  const iframes = document.querySelectorAll(`iframe[data-plugin-id="${PLUGIN_ID}"]`);
   if (!iframes.length) return;
 
   // Fetch tags from host context (more API access than the sandboxed iframe)
@@ -54,8 +70,8 @@ PluginAPI.registerHook(PluginAPI.Hooks.ACTION, async (action) => {
   }
 
   iframes.forEach((iframe) => {
-    if (iframe.src && iframe.src.includes('index.html')) {
-      console.log("[sp-dashboard plugin] sending SP_STATE_CHANGED to", iframe.src);
+    if (iframe.contentWindow) {
+      console.log("[sp-dashboard plugin] sending SP_STATE_CHANGED to dashboard iframe");
       iframe.contentWindow.postMessage({
         type: 'SP_STATE_CHANGED',
         tags


### PR DESCRIPTION
## What

Corrects the sender-identity check added in #11 (released as v1.5.1). That fix matched the sender against `iframe.src.includes('index.html')`, but Super Productivity loads every plugin's view via `iframe.srcdoc` with no `src` URL at all (confirmed against the host app's `plugin-index.component.html`). That check never matches anything against the real DOM shape.

## Impact of v1.5.1 (why this is urgent)

- **Share → Download PNG (and any export) is completely broken** for real users on v1.5.1 — the guard rejects every `SP_DASHBOARD_DOWNLOAD` message, legitimate or not.
- The intended fix in #11 also didn't actually close the hole it targeted: a forged message from a different plugin's iframe would have been rejected by the same broken check for the wrong reason, not a real identity check.
- Separately (pre-existing, not introduced by #11): the `SP_STATE_CHANGED` broadcast on the ACTION hook relies on the same `src` check and has apparently never reached the dashboard iframe in production.

## Fix

The host marks each plugin's iframe with `data-plugin-id`, and since the iframe has `allow-same-origin`, the sender `Window`'s `frameElement` can be read directly to get the exact DOM element that sent a message. Both the download guard and the ACTION broadcaster now match on `data-plugin-id === 'sp-dashboard'`.

## Testing

Live (Puppeteer), against a harness matching the real production DOM shape this time (`srcdoc`, no `src`, `data-plugin-id`, `allow-same-origin` sandbox) — this is what the previous PR's testing missed:
- Legit Share → Download PNG now saves the file (v1.5.1 silently blocked it).
- A forged `SP_DASHBOARD_DOWNLOAD` from a different plugin's iframe (`data-plugin-id="other-plugin"`) is blocked.
- The ACTION hook now actually reaches the dashboard iframe with `SP_STATE_CHANGED` (v1.5.1: silent no-op).
- `npm test` — all 49 existing tests pass unchanged.