### PR TITLE
fix: harden settings import and the plugin's message channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ JSON blob with a `schemaVersion`. Nothing else in `index.html` touches `localSto
 
 ```
 DEFAULT_SETTINGS          → the complete key list; also the type contract
+SETTING_OPTIONS           → legal values + labels for every enumerated setting
+SETTING_RANGES / _ITEMS   → bounds for free-form numbers; legal array members
 readStoredSettings()      → parse + migrate legacy keys + coerce against defaults
 getSetting(key)           → the only read path
 setSetting(key, value)    → write + persist + applySettings()
@@ -57,18 +59,48 @@ rememberSetting(key, val) → record a dashboard control's last value (no re-ren
 applySettings()           → applyAppearance + restartLiveUpdate + processData + re-render panel
 ```
 
-- A stored value whose type doesn't match its default is replaced by the default (`coerceSetting`),
-  and unknown keys are dropped. A hand-edited blob can't wedge the UI.
+**Adding a setting** — all four steps, in this order:
+
+1. A key in `DEFAULT_SETTINGS` (this is the type contract).
+2. If it is enumerated, its values in `SETTING_OPTIONS`; if it is a free-form number, its bounds in
+   `SETTING_RANGES`; if it is an array, its legal members in `SETTING_ITEMS`.
+3. A row in `SETTINGS_SECTIONS` whose control references `SETTING_OPTIONS.<key>` — never an inline
+   option list, or the UI and the validator will drift.
+4. A `getSetting()` read at the point of use. No HTML edit; the modal is generated.
+
+Control types: `select`, `seg`, `radio`, `checks`, `toggle`, `days`, `chips`, `number`, `text`,
+`swatches`.
+
+**Validation is not optional.** `coerceSetting` checks the *value*, not just its type: an enumerated
+setting must name one of its options, a number is clamped, array members are filtered, and unknown
+keys are dropped. Skipping step 2 leaves a setting that accepts anything a JSON file contains —
+which is how a bad `tabPinned` used to throw inside `switchTab()` during init and take the whole
+dashboard down with it. A test walks every control in `SETTINGS_SECTIONS` and imports each of its
+options, so a setting wired up without step 2 will fail the suite.
+
+Prefer allowlists throughout: name what is permitted rather than what is forbidden. The guards here
+all follow that shape, including the CSV export, which leaves a cell bare only when it opens with a
+letter or digit rather than stripping a known-bad set of formula characters.
+
 - The nine pre-settings keys (`sp-dashboard-date-preset`, `-pie-dim`, …) are folded in once on
   first load via `LEGACY_KEY_MAP`, then deleted.
 - **Remember vs pin**: controls in Settings › Defaults have a `*Mode` / `*Pinned` / `*Last` triple,
-  resolved by `resolveDefault()`. `remember` replays `*Last`; `pin` always uses `*Pinned`.
-- The modal UI is **generated from `SETTINGS_SECTIONS`**, not written as markup. Adding a setting is
-  one entry in `DEFAULT_SETTINGS`, one row in `SETTINGS_SECTIONS`, and one `getSetting()` read at the
-  point of use — no HTML edit. Control types: `select`, `seg`, `radio`, `checks`, `toggle`, `days`,
-  `chips`, `number`, `text`, `swatches`.
+  resolved by `resolveDefault()`. `remember` replays `*Last`; `pin` always uses `*Pinned`. The
+  `*Last` keys are validated too — several of them reach the same code paths as their `*Pinned` twin.
 - Settings deliberately live in a modal, **not** a fourth tab: the tab bar feeds Share / Print /
   Copy-image, and settings must never appear in an exported report.
+
+### Untrusted input
+
+Three things arriving from outside are treated as hostile, and each has regression tests:
+
+- **Imported settings files** — see validation above.
+- **`postMessage` into the iframe** — only `window.parent` is accepted, mirroring the sender check
+  `plugin.js` performs in the other direction (`isOwnPluginWindow`). Anything sharing the host page,
+  including another installed plugin, can otherwise reach this frame. Incoming tags are rebuilt into
+  a clean list rather than assigned wholesale.
+- **Task, project and tag names** — host data that may contain markup. Anything data-derived reaching
+  `innerHTML` goes through `escapeHtml()`; prefer `textContent` where possible.
 
 ### Debug logging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sp-dashboard",
-  "version": "1.6.0-rc",
+  "version": "1.6.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sp-dashboard",
-      "version": "1.6.0-rc",
+      "version": "1.6.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-dashboard",
-  "version": "1.6.0-rc",
+  "version": "1.6.0-rc.2",
   "description": "A visual dashboard plugin providing metrics, charts, and daily summaries of your tasks and tracked time.",
   "type": "module",
   "scripts": {

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -3198,8 +3198,22 @@
       }
     };
 
-    // Listen for the light refresh trigger from plugin.js
+    // Listen for the light refresh trigger from plugin.js.
+    //
+    // plugin.js runs in the host page and posts into this frame, so the only
+    // legitimate sender is our immediate parent. Without this check anything
+    // holding a handle on this iframe — another installed plugin, for instance
+    // — can replace the tag list and quietly change what the charts, tables and
+    // exports report. This is the mirror of the sender check plugin.js already
+    // performs in the other direction (isOwnPluginWindow).
+    //
+    // Standalone file:// development still works: with no parent frame,
+    // window.parent === window, so the mock data path is unaffected.
     window.addEventListener('message', (event) => {
+      if (event.source !== window.parent) {
+        debugWarn("[sp-dashboard] ignoring message from an unexpected sender");
+        return;
+      }
       debugLog("[sp-dashboard] message event received in iframe", event.data);
       if (event.data && event.data.type === 'SP_STATE_CHANGED') {
         if (Array.isArray(event.data.tags) && event.data.tags.length > 0) {

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -873,14 +873,128 @@
       'sp-dashboard-drill-entity': 'drillEntityLast'
     };
 
-    // Coerce a stored value against its default, so a hand-edited or stale blob
-    // can never put the dashboard into a state the UI can't represent.
-    const coerceSetting = (def, val) => {
+    const sOpt = (v, l) => ({ v, l });
+
+    // The legal values for every enumerated setting, with the labels the UI
+    // shows. This is the ONLY list: SETTINGS_SECTIONS builds its controls from
+    // it, and coerceSetting validates against it, so the two cannot drift.
+    const METRIC_OPTIONS = [
+      sOpt('time', 'Time tracked'), sOpt('completed', 'Tasks completed'),
+      sOpt('overdue', 'Tasks overdue'), sOpt('late', 'Completed late')
+    ];
+    const MODE_OPTIONS = [sOpt('remember', 'Remember'), sOpt('pin', 'Pin')];
+    const DIM_OPTIONS = [sOpt('project', 'Project'), sOpt('tag', 'Tag')];
+
+    const SETTING_OPTIONS = {
+      weekStartsOn: [sOpt(1, 'Monday'), sOpt(0, 'Sunday'), sOpt(6, 'Saturday')],
+      dateFormat: [sOpt('auto', 'Auto (locale)'), sOpt('iso', 'ISO — 2026-02-22'),
+                   sOpt('us', 'Feb 22, 2026'), sOpt('eu', '22 Feb 2026')],
+      timeFormat: [sOpt('hm', '3h 45m'), sOpt('decimal', '3.75h — decimal'), sOpt('minutes', '225m')],
+      periodMode: MODE_OPTIONS,
+      periodPinned: [sOpt('today', 'Today'), sOpt('this-week', 'This Week'), sOpt('week', 'Past Week'),
+                     sOpt('month', 'This Month'), sOpt('year', 'Past Year'),
+                     sOpt('from-weekday', 'Starting from weekday')],
+      tabMode: MODE_OPTIONS,
+      tabPinned: [sOpt('dashboard', 'Dashboard'), sOpt('details', 'Detailed List'),
+                  sOpt('drilldown', 'By Project / Tag')],
+      barMetricMode: MODE_OPTIONS,
+      barMetricPinned: METRIC_OPTIONS,
+      pieMetricMode: MODE_OPTIONS,
+      pieMetricPinned: METRIC_OPTIONS,
+      pieDimPinned: DIM_OPTIONS,
+      sortKey: [sOpt('date', 'Date'), sOpt('projectName', 'Project'), sOpt('taskTitle', 'Task'),
+                sOpt('timeSpent', 'Time Spent'), sOpt('status', 'Status')],
+      sortDir: [sOpt('asc', 'Ascending'), sOpt('desc', 'Descending')],
+      drillDimMode: MODE_OPTIONS,
+      drillDimPinned: DIM_OPTIONS,
+      minEntryMs: [sOpt(0, 'Off'), sOpt(60000, '1 minute'), sOpt(300000, '5 minutes'), sOpt(900000, '15 minutes')],
+      theme: [sOpt('auto', 'Follow app'), sOpt('light', 'Light'), sOpt('dark', 'Dark')],
+      palette: [sOpt('default', 'Default'), sOpt('colorblind', 'Colourblind-safe'),
+                sOpt('mono', 'Monochrome'), sOpt('contrast', 'High contrast')],
+      barGrouping: [sOpt('auto', 'Auto'), sOpt('daily', 'Daily'), sOpt('weekly', 'Weekly'), sOpt('monthly', 'Monthly')],
+      pieMaxSlices: [sOpt(0, 'Show all slices'), sOpt(5, 'Top 5, rest as Other'),
+                     sOpt(8, 'Top 8, rest as Other'), sOpt(10, 'Top 10, rest as Other')],
+      density: [sOpt('comfortable', 'Comfortable'), sOpt('compact', 'Compact')],
+      tablePageSize: [sOpt(50, '50'), sOpt(100, '100'), sOpt(250, '250'), sOpt(0, 'All')],
+      refreshMs: [sOpt(0, 'Off'), sOpt(10000, 'Every 10 seconds'), sOpt(30000, 'Every 30 seconds'),
+                  sOpt(60000, 'Every minute'), sOpt(300000, 'Every 5 minutes')],
+      summaryFormat: [sOpt('slack', 'Slack'), sOpt('markdown', 'Markdown'), sOpt('csv', 'CSV')]
+    };
+
+    // The `*Last` keys record what a dashboard control was last set to, so they
+    // are validated too — `tabLast` reaches switchTab() exactly as `tabPinned`
+    // does. They allow '' ("nothing remembered yet") and, where the control can
+    // reach a state that is not offered as a pinnable default, a little more
+    // than their `*Pinned` twin: Period can be left on a custom range.
+    const SETTING_LAST_VALUES = {
+      periodLast: ['today', 'this-week', 'week', 'month', 'year', 'custom', 'from-weekday'],
+      tabLast: ['dashboard', 'details', 'drilldown'],
+      barMetricLast: ['time', 'completed', 'overdue', 'late'],
+      pieMetricLast: ['time', 'completed', 'overdue', 'late'],
+      pieDimLast: ['project', 'tag'],
+      drillDimLast: ['project', 'tag'],
+      weekdayLast: ['0', '1', '2', '3', '4', '5', '6']
+    };
+
+    // Free-form numbers the user types, rather than picks. Clamped, not enumerated.
+    const SETTING_RANGES = {
+      dailyTimeGoalH: [1, 24],
+      weeklyTimeGoalH: [1, 168],
+      dailyTaskGoal: [1, 99]
+    };
+
+    // Legal members of the array-valued settings. Anything else is discarded.
+    // excludedProjects / excludedTags are omitted: they hold arbitrary project
+    // and tag names, so they are only checked for being strings.
+    const SETTING_ITEMS = {
+      workingDays: [0, 1, 2, 3, 4, 5, 6],
+      statCards: ['time', 'completed', 'overdue', 'late']
+    };
+
+    const MAX_EXCLUSIONS = 500;      // a vault will not have more than this
+    const MAX_EXCLUSION_LEN = 300;   // longest plausible project or tag name
+    const MAX_FILENAME_PATTERN = 200;
+
+    // Coerce a stored value against its default, so a hand-edited, corrupted or
+    // hostile blob can never put the dashboard into a state the UI can't
+    // represent. Type is checked first, then the value itself: an enumerated
+    // setting must name one of its options and a ranged one is clamped.
+    // Without this a bad `tabPinned` throws during init and takes the whole
+    // dashboard down with it.
+    const coerceSetting = (key, def, val) => {
       if (val === undefined || val === null) return Array.isArray(def) ? def.slice() : def;
-      if (Array.isArray(def)) return Array.isArray(val) ? val.slice() : def.slice();
-      if (typeof def === 'number') return (typeof val === 'number' && isFinite(val)) ? val : def;
+
+      if (Array.isArray(def)) {
+        if (!Array.isArray(val)) return def.slice();
+        const allowedItems = SETTING_ITEMS[key];
+        if (allowedItems) return val.filter(v => allowedItems.indexOf(v) !== -1);
+        return val
+          .filter(v => typeof v === 'string' && v.length > 0 && v.length <= MAX_EXCLUSION_LEN)
+          .slice(0, MAX_EXCLUSIONS);
+      }
+
       if (typeof def === 'boolean') return typeof val === 'boolean' ? val : def;
-      return typeof val === 'string' ? val : def;
+
+      if (typeof def === 'number') {
+        if (typeof val !== 'number' || !isFinite(val)) return def;
+        const options = SETTING_OPTIONS[key];
+        if (options) return options.some(o => o.v === val) ? val : def;
+        const range = SETTING_RANGES[key];
+        if (range) return Math.min(range[1], Math.max(range[0], Math.round(val)));
+        return val;
+      }
+
+      if (typeof val !== 'string') return def;
+      const options = SETTING_OPTIONS[key];
+      if (options) return options.some(o => o.v === val) ? val : def;
+      const lastValues = SETTING_LAST_VALUES[key];
+      if (lastValues) return (val === '' || lastValues.indexOf(val) !== -1) ? val : def;
+      if (key === 'dateFromLast' || key === 'dateToLast') {
+        return (val === '' || /^\d{4}-\d{2}-\d{2}$/.test(val)) ? val : def;
+      }
+      if (key === 'drillEntityLast') return val.slice(0, MAX_EXCLUSION_LEN);
+      if (key === 'exportFilename') return val.slice(0, MAX_FILENAME_PATTERN) || def;
+      return val;
     };
 
     const readStoredSettings = () => {
@@ -906,7 +1020,7 @@
 
       const merged = {};
       Object.keys(DEFAULT_SETTINGS).forEach(key => {
-        merged[key] = coerceSetting(DEFAULT_SETTINGS[key], stored[key]);
+        merged[key] = coerceSetting(key, DEFAULT_SETTINGS[key], stored[key]);
       });
       merged.schemaVersion = SETTINGS_SCHEMA_VERSION;
 
@@ -1005,14 +1119,19 @@
     };
 
     // --- TAB LOGIC ---
+    const TAB_IDS = ['dashboard', 'details', 'drilldown'];
     const switchTab = (tabId) => {
-      ['dashboard', 'details', 'drilldown'].forEach(id => {
+      // Fall back rather than throw: switchTab runs during init from a stored
+      // setting, and a null dereference here would abort the rest of the script
+      // — leaving no visible view and no data ever loaded.
+      const target = TAB_IDS.indexOf(tabId) !== -1 ? tabId : TAB_IDS[0];
+      TAB_IDS.forEach(id => {
         document.getElementById(`view-${id}`).classList.add('hidden');
         document.getElementById(`tab-btn-${id}`).classList.remove('active');
       });
-      document.getElementById(`view-${tabId}`).classList.remove('hidden');
-      document.getElementById(`tab-btn-${tabId}`).classList.add('active');
-      rememberSetting('tabLast', tabId);
+      document.getElementById(`view-${target}`).classList.remove('hidden');
+      document.getElementById(`tab-btn-${target}`).classList.add('active');
+      rememberSetting('tabLast', target);
     };
 
     // --- GLOBALS ---
@@ -2396,13 +2515,8 @@
     // The panel is generated from SETTINGS_SECTIONS rather than written out as
     // markup, so a new setting is one entry here plus one read of getSetting().
     // ==========================================================
-    const sOpt = (v, l) => ({ v, l });
-
-    const METRIC_OPTIONS = [
-      sOpt('time', 'Time tracked'), sOpt('completed', 'Tasks completed'),
-      sOpt('overdue', 'Tasks overdue'), sOpt('late', 'Completed late')
-    ];
-    const MODE_OPTIONS = [sOpt('remember', 'Remember'), sOpt('pin', 'Pin')];
+    // Option lists come from SETTING_OPTIONS above, so the controls a user can
+    // reach and the values coerceSetting will accept are the same list.
     const DAY_LETTERS = [sOpt(0, 'S'), sOpt(1, 'M'), sOpt(2, 'T'), sOpt(3, 'W'), sOpt(4, 'T'), sOpt(5, 'F'), sOpt(6, 'S')];
 
     const SETTINGS_SECTIONS = [
@@ -2411,15 +2525,11 @@
         sub: 'Formats and locale, applied to every view',
         rows: [
           { label: 'Start of week', hint: 'Drives “This Week” and the day the weekly bar chart starts on',
-            controls: [{ type: 'select', key: 'weekStartsOn', numeric: true,
-              options: [sOpt(1, 'Monday'), sOpt(0, 'Sunday'), sOpt(6, 'Saturday')] }] },
+            controls: [{ type: 'select', key: 'weekStartsOn', numeric: true, options: SETTING_OPTIONS.weekStartsOn }] },
           { label: 'Date format', hint: 'Auto follows the host app’s locale',
-            controls: [{ type: 'select', key: 'dateFormat', options: [
-              sOpt('auto', 'Auto (locale)'), sOpt('iso', 'ISO — 2026-02-22'),
-              sOpt('us', 'Feb 22, 2026'), sOpt('eu', '22 Feb 2026')] }] },
+            controls: [{ type: 'select', key: 'dateFormat', options: SETTING_OPTIONS.dateFormat }] },
           { label: 'Time format', hint: 'Decimal hours is what pastes into a timesheet or invoice',
-            controls: [{ type: 'radio', key: 'timeFormat', options: [
-              sOpt('hm', '3h 45m'), sOpt('decimal', '3.75h — decimal'), sOpt('minutes', '225m')] }] },
+            controls: [{ type: 'radio', key: 'timeFormat', options: SETTING_OPTIONS.timeFormat }] },
           { label: 'Working days', hint: 'Used by the setting below',
             controls: [{ type: 'days', key: 'workingDays', options: DAY_LETTERS }] },
           { label: 'Hide non-working days in charts', hint: 'Removes those days from the range entirely, so weekends stop flattening the chart',
@@ -2431,32 +2541,25 @@
         sub: 'What each control shows when the dashboard opens. Remember keeps the last used value; Pin always starts from a fixed one.',
         rows: [
           { label: 'Period', controls: [
-            { type: 'seg', key: 'periodMode', options: MODE_OPTIONS },
-            { type: 'select', key: 'periodPinned', disabledWhen: { key: 'periodMode', is: 'remember' }, options: [
-              sOpt('today', 'Today'), sOpt('this-week', 'This Week'), sOpt('week', 'Past Week'),
-              sOpt('month', 'This Month'), sOpt('year', 'Past Year'), sOpt('from-weekday', 'Starting from weekday')] }] },
+            { type: 'seg', key: 'periodMode', options: SETTING_OPTIONS.periodMode },
+            { type: 'select', key: 'periodPinned', disabledWhen: { key: 'periodMode', is: 'remember' }, options: SETTING_OPTIONS.periodPinned }] },
           { label: 'Opening tab', controls: [
-            { type: 'seg', key: 'tabMode', options: MODE_OPTIONS },
-            { type: 'select', key: 'tabPinned', disabledWhen: { key: 'tabMode', is: 'remember' }, options: [
-              sOpt('dashboard', 'Dashboard'), sOpt('details', 'Detailed List'), sOpt('drilldown', 'By Project / Tag')] }] },
+            { type: 'seg', key: 'tabMode', options: SETTING_OPTIONS.tabMode },
+            { type: 'select', key: 'tabPinned', disabledWhen: { key: 'tabMode', is: 'remember' }, options: SETTING_OPTIONS.tabPinned }] },
           { label: 'Bar chart metric', controls: [
-            { type: 'seg', key: 'barMetricMode', options: MODE_OPTIONS },
-            { type: 'select', key: 'barMetricPinned', disabledWhen: { key: 'barMetricMode', is: 'remember' }, options: METRIC_OPTIONS }] },
+            { type: 'seg', key: 'barMetricMode', options: SETTING_OPTIONS.barMetricMode },
+            { type: 'select', key: 'barMetricPinned', disabledWhen: { key: 'barMetricMode', is: 'remember' }, options: SETTING_OPTIONS.barMetricPinned }] },
           { label: 'Pie chart metric & split', controls: [
-            { type: 'seg', key: 'pieMetricMode', options: MODE_OPTIONS },
-            { type: 'select', key: 'pieMetricPinned', disabledWhen: { key: 'pieMetricMode', is: 'remember' }, options: METRIC_OPTIONS },
-            { type: 'seg', key: 'pieDimPinned', disabledWhen: { key: 'pieMetricMode', is: 'remember' },
-              options: [sOpt('project', 'Project'), sOpt('tag', 'Tag')] }] },
+            { type: 'seg', key: 'pieMetricMode', options: SETTING_OPTIONS.pieMetricMode },
+            { type: 'select', key: 'pieMetricPinned', disabledWhen: { key: 'pieMetricMode', is: 'remember' }, options: SETTING_OPTIONS.pieMetricPinned },
+            { type: 'seg', key: 'pieDimPinned', disabledWhen: { key: 'pieMetricMode', is: 'remember' }, options: SETTING_OPTIONS.pieDimPinned }] },
           { label: 'Detailed List sort', hint: 'Where the table starts before you click a column header',
             controls: [
-              { type: 'select', key: 'sortKey', options: [
-                sOpt('date', 'Date'), sOpt('projectName', 'Project'), sOpt('taskTitle', 'Task'),
-                sOpt('timeSpent', 'Time Spent'), sOpt('status', 'Status')] },
-              { type: 'seg', key: 'sortDir', options: [sOpt('asc', 'Ascending'), sOpt('desc', 'Descending')] }] },
+              { type: 'select', key: 'sortKey', options: SETTING_OPTIONS.sortKey },
+              { type: 'seg', key: 'sortDir', options: SETTING_OPTIONS.sortDir }] },
           { label: 'By Project / Tag split', controls: [
-            { type: 'seg', key: 'drillDimMode', options: MODE_OPTIONS },
-            { type: 'seg', key: 'drillDimPinned', disabledWhen: { key: 'drillDimMode', is: 'remember' },
-              options: [sOpt('project', 'Project'), sOpt('tag', 'Tag')] }] }
+            { type: 'seg', key: 'drillDimMode', options: SETTING_OPTIONS.drillDimMode },
+            { type: 'seg', key: 'drillDimPinned', disabledWhen: { key: 'drillDimMode', is: 'remember' }, options: SETTING_OPTIONS.drillDimPinned }] }
         ]
       },
       {
@@ -2475,8 +2578,7 @@
           { label: 'List subtasks as their own rows', hint: 'Detailed List only — a parent’s time already rolls up its subtasks, so totals never change',
             controls: [{ type: 'toggle', key: 'showSubtaskRows' }] },
           { label: 'Minimum entry length', hint: 'Keeps 30-second scraps out of the totals and the table',
-            controls: [{ type: 'select', key: 'minEntryMs', numeric: true, options: [
-              sOpt(0, 'Off'), sOpt(60000, '1 minute'), sOpt(300000, '5 minutes'), sOpt(900000, '15 minutes')] }] },
+            controls: [{ type: 'select', key: 'minEntryMs', numeric: true, options: SETTING_OPTIONS.minEntryMs }] },
           { label: 'Tasks with no due date', hint: 'Replaces the fixed footnote under the Overdue card',
             controls: [{ type: 'radio', key: 'noDueDateOverdue', options: [
               sOpt(false, 'Never overdue'), sOpt(true, 'Count as overdue')] }] },
@@ -2489,31 +2591,23 @@
         sub: 'Purely visual — nothing here changes a number',
         rows: [
           { label: 'Theme', hint: 'Follow app mirrors the host’s own light/dark class',
-            controls: [{ type: 'seg', key: 'theme', options: [
-              sOpt('auto', 'Follow app'), sOpt('light', 'Light'), sOpt('dark', 'Dark')] }] },
+            controls: [{ type: 'seg', key: 'theme', options: SETTING_OPTIONS.theme }] },
           { label: 'Chart palette', hint: 'Used by the pie chart and its legend',
             controls: [
-              { type: 'select', key: 'palette', options: [
-                sOpt('default', 'Default'), sOpt('colorblind', 'Colourblind-safe'),
-                sOpt('mono', 'Monochrome'), sOpt('contrast', 'High contrast')] },
+              { type: 'select', key: 'palette', options: SETTING_OPTIONS.palette },
               { type: 'swatches' }] },
           { label: 'Bar chart grouping', hint: 'Auto keeps the existing rules: daily under a month, weekly for a month, monthly beyond',
-            controls: [{ type: 'select', key: 'barGrouping', options: [
-              sOpt('auto', 'Auto'), sOpt('daily', 'Daily'), sOpt('weekly', 'Weekly'), sOpt('monthly', 'Monthly')] }] },
+            controls: [{ type: 'select', key: 'barGrouping', options: SETTING_OPTIONS.barGrouping }] },
           { label: 'Small pie slices', hint: 'Rolls everything past the top N into one “Other” slice',
-            controls: [{ type: 'select', key: 'pieMaxSlices', numeric: true, options: [
-              sOpt(0, 'Show all slices'), sOpt(5, 'Top 5, rest as Other'),
-              sOpt(8, 'Top 8, rest as Other'), sOpt(10, 'Top 10, rest as Other')] }] },
+            controls: [{ type: 'select', key: 'pieMaxSlices', numeric: true, options: SETTING_OPTIONS.pieMaxSlices }] },
           { label: 'Density',
-            controls: [{ type: 'seg', key: 'density', options: [
-              sOpt('comfortable', 'Comfortable'), sOpt('compact', 'Compact')] }] },
+            controls: [{ type: 'seg', key: 'density', options: SETTING_OPTIONS.density }] },
           { label: 'Stat cards', hint: 'Unchecked cards are hidden and the row re-flows',
             controls: [{ type: 'checks', key: 'statCards', options: [
               sOpt('time', 'Total time tracked'), sOpt('completed', 'Tasks completed'),
               sOpt('overdue', 'Tasks overdue'), sOpt('late', 'Completed late')] }] },
           { label: 'Detailed List rows per page',
-            controls: [{ type: 'seg', key: 'tablePageSize', numeric: true, options: [
-              sOpt(50, '50'), sOpt(100, '100'), sOpt(250, '250'), sOpt(0, 'All')] }] }
+            controls: [{ type: 'seg', key: 'tablePageSize', numeric: true, options: SETTING_OPTIONS.tablePageSize }] }
         ]
       },
       {
@@ -2542,16 +2636,13 @@
         sub: 'Refresh, export and the settings file itself',
         rows: [
           { label: 'Auto-refresh', hint: 'The dashboard also refreshes whenever the host app reports a change, so Off is not the same as stale',
-            controls: [{ type: 'select', key: 'refreshMs', numeric: true, options: [
-              sOpt(0, 'Off'), sOpt(10000, 'Every 10 seconds'), sOpt(30000, 'Every 30 seconds'),
-              sOpt(60000, 'Every minute'), sOpt(300000, 'Every 5 minutes')] }] },
+            controls: [{ type: 'select', key: 'refreshMs', numeric: true, options: SETTING_OPTIONS.refreshMs }] },
           { label: 'Debug logging', hint: 'Off by default: one log line per task, per refresh', hintWarn: true,
             controls: [{ type: 'toggle', key: 'debugLogging' }] },
           { label: 'Export filename', hint: 'Used by Download PNG. Tokens: {tab} {range} {date}',
             controls: [{ type: 'text', key: 'exportFilename', placeholder: DEFAULT_SETTINGS.exportFilename }] },
           { label: 'Copy text summary as',
-            controls: [{ type: 'seg', key: 'summaryFormat', options: [
-              sOpt('slack', 'Slack'), sOpt('markdown', 'Markdown'), sOpt('csv', 'CSV')] }] }
+            controls: [{ type: 'seg', key: 'summaryFormat', options: SETTING_OPTIONS.summaryFormat }] }
         ],
         danger: true
       }
@@ -2866,7 +2957,7 @@
         return;
       }
       Object.keys(DEFAULT_SETTINGS).forEach(key => {
-        SETTINGS[key] = coerceSetting(DEFAULT_SETTINGS[key], parsed[key]);
+        SETTINGS[key] = coerceSetting(key, DEFAULT_SETTINGS[key], parsed[key]);
       });
       SETTINGS.schemaVersion = SETTINGS_SCHEMA_VERSION;
       persistSettings();

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -954,6 +954,23 @@
     const MAX_EXCLUSIONS = 500;      // a vault will not have more than this
     const MAX_EXCLUSION_LEN = 300;   // longest plausible project or tag name
     const MAX_FILENAME_PATTERN = 200;
+    const MAX_TAGS = 2000;
+
+    // Tags arrive over postMessage, so they are host input rather than our own
+    // data. Build a clean list of exactly the two fields we use rather than
+    // filtering a dirty one — anything else on the incoming objects is dropped
+    // by never being copied across, which needs no list of what to reject.
+    const sanitizeIncomingTags = (raw) => {
+      const out = [];
+      for (const tag of raw) {
+        if (out.length >= MAX_TAGS) break;
+        if (!tag || typeof tag !== 'object') continue;
+        if (typeof tag.id !== 'string' || !tag.id || tag.id.length > MAX_EXCLUSION_LEN) continue;
+        const title = (typeof tag.title === 'string' && tag.title) ? tag.title : tag.id;
+        out.push({ id: tag.id, title: title.slice(0, MAX_EXCLUSION_LEN) });
+      }
+      return out;
+    };
 
     // Coerce a stored value against its default, so a hand-edited, corrupted or
     // hostile blob can never put the dashboard into a state the UI can't
@@ -2276,8 +2293,15 @@
         .replace(/\{tab\}/g, slug(label))
         .replace(/\{range\}/g, slug(getRangeLabel()))
         .replace(/\{date\}/g, toLocalDate(new Date()))
+        // Allowlist the permitted characters rather than stripping known-bad
+        // ones: path separators, quotes and control characters all collapse to
+        // a hyphen because they are simply not on the list.
         .replace(/[^a-zA-Z0-9._-]+/g, '-')
-        .replace(/^-+|-+$/g, '');
+        // Leading dots and hyphens are dropped separately — a name like
+        // "..-cfg" or "-rf" is made only of permitted characters but still
+        // reads as a traversal attempt or a flag to whatever opens it.
+        .replace(/^[.\-]+/, '')
+        .replace(/-+$/, '');
       return `${name || 'dashboard'}.${ext}`;
     };
 
@@ -2360,13 +2384,21 @@
     // Settings › Advanced › Copy text summary as → CSV.
     const buildCsvSummary = (tabKey) => {
       const m = window.latestMetrics || latestMetrics;
+      // A cell is left bare only when it opens with a character we know is
+      // inert — a letter or a digit. Everything else gets the apostrophe that
+      // forces a spreadsheet to treat it as text.
+      //
+      // Deliberately an allowlist. The usual advice is to strip a known-bad set
+      // (= + - @ tab CR), but that list differs between Excel, LibreOffice and
+      // Sheets and grows over time, so anything omitted becomes a live formula
+      // in someone else's application. Starting from "inert unless proven
+      // otherwise" costs a leading apostrophe on names like "(internal)" —
+      // which spreadsheets do not display — and cannot be outflanked by a
+      // character nobody thought of.
+      const INERT_CELL_START = /^[\p{L}\p{N}]/u;
       const cell = (v) => {
         let s = String(v == null ? '' : v);
-        // Excel and LibreOffice evaluate a cell starting with =, +, - or @ as a
-        // formula, so a task named `=cmd|'/c calc'!A1` would run on open. A
-        // leading apostrophe is the conventional way to force text; it is not
-        // displayed by the spreadsheet.
-        if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+        if (s !== '' && !INERT_CELL_START.test(s)) s = `'${s}`;
         return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
       };
       const row = (cells) => cells.map(cell).join(',');
@@ -3217,7 +3249,8 @@
       debugLog("[sp-dashboard] message event received in iframe", event.data);
       if (event.data && event.data.type === 'SP_STATE_CHANGED') {
         if (Array.isArray(event.data.tags) && event.data.tags.length > 0) {
-          cachedTags = event.data.tags;
+          const tags = sanitizeIncomingTags(event.data.tags);
+          if (tags.length > 0) cachedTags = tags;
         }
         pullDataFromSP();
       }

--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -2361,7 +2361,12 @@
     const buildCsvSummary = (tabKey) => {
       const m = window.latestMetrics || latestMetrics;
       const cell = (v) => {
-        const s = String(v == null ? '' : v);
+        let s = String(v == null ? '' : v);
+        // Excel and LibreOffice evaluate a cell starting with =, +, - or @ as a
+        // formula, so a task named `=cmd|'/c calc'!A1` would run on open. A
+        // leading apostrophe is the conventional way to force text; it is not
+        // displayed by the spreadsheet.
+        if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
         return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
       };
       const row = (cells) => cells.map(cell).join(',');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1035,6 +1035,27 @@ describe('Date Range Reporter UI', () => {
         expect(tagPickerOptions()).toContain('FromHost');
       });
 
+      it('keeps only well-formed tags from the host message', () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'SP_STATE_CHANGED', tags: [
+            { id: 'good', title: 'Keep' },
+            { id: 'no-title' },                       // title falls back to id
+            'a string', null, 42, [],                 // not objects at all
+            { title: 'no id' },                       // unusable without an id
+            { id: '', title: 'empty id' },
+            { id: 'extra', title: 'Fields', evil: () => {}, __proto__: { x: 1 } }
+          ] },
+          source: window.parent
+        }));
+        const opts = tagPickerOptions();
+        expect(opts).toContain('Keep');
+        expect(opts).toContain('no-title');   // id used as the label
+        expect(opts).toContain('Fields');
+        expect(opts).not.toContain('no id');
+        expect(opts).not.toContain('empty id');
+        expect({}.x).toBeUndefined();
+      });
+
       it('ignores SP_STATE_CHANGED from any other sender', () => {
         // plugin.js posts from the host page. Anything else with a handle on
         // this frame — another installed plugin — must not drive our state.
@@ -1295,6 +1316,20 @@ describe('Date Range Reporter UI', () => {
         expect(window.buildExportFilename('Dashboard', 'png')).toBe(`x-${todayStr}.png`);
       });
 
+      it('exportFilename cannot produce a traversal or flag-like name', () => {
+        window.processData(tasks, projects, tags);
+        [
+          ['../../etc/passwd', 'etc-passwd.png'],
+          ['..', 'dashboard.png'],
+          ['-rf', 'rf.png'],
+          ['.hidden', 'hidden.png'],
+          ['a/b\\c:d*e?f"g<h>i|j', 'a-b-c-d-e-f-g-h-i-j.png']
+        ].forEach(([pattern, expected]) => {
+          window.setSetting('exportFilename', pattern);
+          expect(window.buildExportFilename('Dashboard', 'png'), pattern).toBe(expected);
+        });
+      });
+
       it('summaryFormat switches the copied summary between Slack, Markdown and CSV', () => {
         // setSetting re-runs processData over the cached task list, which is
         // empty here, so each format is re-fed the fixtures before asserting.
@@ -1310,6 +1345,25 @@ describe('Date Range Reporter UI', () => {
         const csv = window.buildTextSummary('dashboard');
         expect(csv.split('\n')[0]).toBe('Metric,Value');
         expect(csv).toContain('Total Time Tracked,2h 30m');
+      });
+
+      it('csv leaves only letter- or digit-initial cells bare', () => {
+        // Allowlist, not denylist: a leading character nobody enumerated must
+        // still be quoted rather than shipped as a live formula.
+        const exotic = ['\tTAB-led', '|DDE', ' null-led', ' space-led', '=classic', '−unicode-minus'];
+        const tasks = exotic.map((title, i) => ({
+          id: 'x' + i, parentId: null, title, isDone: false, projectId: 'p1',
+          tagIds: [], timeSpentOnDay: { [todayStr]: 60000 * (i + 1) }
+        }));
+        window.setSetting('summaryFormat', 'csv');
+        window.processData(tasks, [{ id: 'p1', title: 'Safe' }], []);
+        const csv = window.buildTextSummary('details');
+
+        exotic.forEach(title => {
+          expect(csv, `${JSON.stringify(title)} must be forced to text`).toContain(`'${title}`);
+        });
+        // …while ordinary names stay untouched.
+        expect(csv).toContain(',Safe,');
       });
 
       it('csv summary neutralises spreadsheet formula injection', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1016,6 +1016,45 @@ describe('Date Range Reporter UI', () => {
         expect({}.p2).toBeUndefined();
       });
 
+      // The tag picker in Settings reads the cached tag list, so it doubles as
+      // a window onto what a postMessage did or didn't manage to change.
+      const tagPickerOptions = () => {
+        window.openSettings();
+        window.renderSettingsPanel();
+        document.getElementById('settings-rail').querySelector('[data-section="data"]')
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        const picker = document.querySelectorAll('.set-chips select')[1];
+        return picker ? Array.from(picker.options).map(o => o.textContent) : [];
+      };
+
+      it('accepts SP_STATE_CHANGED from the host frame', () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'SP_STATE_CHANGED', tags: [{ id: 'h1', title: 'FromHost' }] },
+          source: window.parent
+        }));
+        expect(tagPickerOptions()).toContain('FromHost');
+      });
+
+      it('ignores SP_STATE_CHANGED from any other sender', () => {
+        // plugin.js posts from the host page. Anything else with a handle on
+        // this frame — another installed plugin — must not drive our state.
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'SP_STATE_CHANGED', tags: [{ id: 'h1', title: 'FromHost' }] },
+          source: window.parent
+        }));
+        expect(tagPickerOptions()).toContain('FromHost');
+
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'SP_STATE_CHANGED', tags: [{ id: 'e1', title: 'AttackerTag' }] },
+          source: { postMessage() {} }
+        }));
+        const opts = tagPickerOptions();
+        expect(opts).not.toContain('AttackerTag');
+        expect(opts).toContain('FromHost'); // the real list survived
+      });
+    });
+
+    describe('Untrusted input (continued)', () => {
       it('keeps hostile strings as inert text in the settings UI', () => {
         window.importSettings(JSON.stringify({ excludedProjects: ['<img src=x onerror=alert(1)>'] }));
         window.openSettings();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1273,6 +1273,27 @@ describe('Date Range Reporter UI', () => {
         expect(csv).toContain('Total Time Tracked,2h 30m');
       });
 
+      it('csv summary neutralises spreadsheet formula injection', () => {
+        // A CSV export leaves the plugin and is opened by another application,
+        // so a hostile task title must not be evaluated as a formula there.
+        const evil = ['=cmd|\'/c calc\'!A1', '@SUM(1+1)*cmd', '+1-1', '-2+3'].map((title, i) => ({
+          id: 'e' + i, parentId: null, title, isDone: false, projectId: 'p1',
+          tagIds: [], timeSpentOnDay: { [todayStr]: 60000 * (i + 1) }
+        }));
+        window.setSetting('summaryFormat', 'csv');
+        window.processData(evil, [{ id: 'p1', title: '-2+3' }], []);
+        const csv = window.buildTextSummary('details');
+
+        csv.split('\n').slice(1).forEach(line => {
+          line.split(',').forEach(field => {
+            expect(field.replace(/^"/, '')[0]).not.toMatch(/[=+\-@]/);
+          });
+        });
+        expect(csv).toContain("'=cmd|'/c calc'!A1");
+        expect(csv).toContain("'@SUM(1+1)*cmd");
+        expect(csv).toContain("'-2+3"); // the project name too, not just titles
+      });
+
       it('csv summary of the Detailed List quotes fields containing commas', () => {
         const commaTask = [{ id: 'c1', parentId: null, title: 'Fix bug, then test', isDone: false,
           projectId: 'p1', tagIds: [], timeSpentOnDay: { [todayStr]: 3600000 } }];

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -936,6 +936,137 @@ describe('Date Range Reporter UI', () => {
       });
     });
 
+    // An imported settings file is untrusted: it may be shared, stale or simply
+    // corrupt. Type alone is not enough — a well-typed string in the wrong
+    // place used to throw during init and take the whole dashboard down.
+    describe('Untrusted input', () => {
+      const reboot = () => {
+        document.documentElement.innerHTML = html;
+        const script = Array.from(document.querySelectorAll('script'))
+          .find(s => !s.src && s.textContent.includes('processData'));
+        new Function(script.textContent).call(window);
+      };
+
+      it('rejects an out-of-enum tab, which previously threw during init', () => {
+        window.importSettings(JSON.stringify({ tabPinned: 'evil', tabMode: 'pin' }));
+        expect(window.getSetting('tabPinned')).toBe('dashboard');
+        expect(() => reboot()).not.toThrow();
+        expect(document.getElementById('view-dashboard').classList.contains('hidden')).toBe(false);
+      });
+
+      it('rejects an out-of-enum tabLast on the remember path too', () => {
+        window.importSettings(JSON.stringify({ tabLast: 'evil', tabMode: 'remember' }));
+        // Falls back to '' — "nothing remembered" — so tabPinned decides.
+        expect(window.getSetting('tabLast')).toBe('');
+        expect(() => reboot()).not.toThrow();
+        expect(document.getElementById('view-dashboard').classList.contains('hidden')).toBe(false);
+      });
+
+      it('switchTab falls back rather than throwing on an unknown tab', () => {
+        expect(() => window.switchTab('nope')).not.toThrow();
+        expect(document.getElementById('view-dashboard').classList.contains('hidden')).toBe(false);
+      });
+
+      it('rejects out-of-enum values across every enumerated setting', () => {
+        window.importSettings(JSON.stringify({
+          palette: 'constructor', theme: 'evil', barGrouping: 'zzz',
+          periodPinned: 'nope', sortKey: 'toString', summaryFormat: 'xml'
+        }));
+        expect(window.getSetting('palette')).toBe('default');
+        expect(window.getSetting('theme')).toBe('auto');
+        expect(window.getSetting('barGrouping')).toBe('auto');
+        expect(window.getSetting('periodPinned')).toBe('today');
+        expect(window.getSetting('sortKey')).toBe('date');
+        expect(window.getSetting('summaryFormat')).toBe('slack');
+      });
+
+      it('refuses a refresh interval that is not one of the offered values', () => {
+        window.importSettings(JSON.stringify({ refreshMs: 1 }));
+        expect(window.getSetting('refreshMs')).toBe(30000);
+      });
+
+      it('clamps free-form numeric goals to their range', () => {
+        window.importSettings(JSON.stringify({ dailyTimeGoalH: 1e9, weeklyTimeGoalH: -5, dailyTaskGoal: 0 }));
+        expect(window.getSetting('dailyTimeGoalH')).toBe(24);
+        expect(window.getSetting('weeklyTimeGoalH')).toBe(1);
+        expect(window.getSetting('dailyTaskGoal')).toBe(1);
+      });
+
+      it('drops array members that are not legal values', () => {
+        window.importSettings(JSON.stringify({
+          workingDays: [0, 1, 'x', {}, 99],
+          statCards: ['time', '<svg onload=alert(1)>']
+        }));
+        expect(window.getSetting('workingDays')).toEqual([0, 1]);
+        expect(window.getSetting('statCards')).toEqual(['time']);
+      });
+
+      it('caps the exclusion lists so one file cannot bloat the store', () => {
+        window.importSettings(JSON.stringify({
+          excludedProjects: Array.from({ length: 10000 }, (_, i) => 'p' + i),
+          excludedTags: ['ok', 123, null, 'x'.repeat(5000)]
+        }));
+        expect(window.getSetting('excludedProjects').length).toBe(500);
+        expect(window.getSetting('excludedTags')).toEqual(['ok']);
+      });
+
+      it('leaves no prototype pollution behind', () => {
+        window.importSettings('{"__proto__":{"polluted":"yes"},"constructor":{"prototype":{"p2":"yes"}}}');
+        expect({}.polluted).toBeUndefined();
+        expect({}.p2).toBeUndefined();
+      });
+
+      it('keeps hostile strings as inert text in the settings UI', () => {
+        window.importSettings(JSON.stringify({ excludedProjects: ['<img src=x onerror=alert(1)>'] }));
+        window.openSettings();
+        document.getElementById('settings-rail').querySelector('[data-section="data"]')
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        const chip = document.querySelector('.set-chip');
+        expect(chip.textContent).toContain('<img src=x onerror=alert(1)>');
+        expect(document.querySelectorAll('#settings-panel img').length).toBe(0);
+      });
+
+      it('still accepts a legitimate config, including states only the UI reaches', () => {
+        window.importSettings(JSON.stringify({
+          theme: 'dark', palette: 'colorblind', refreshMs: 60000,
+          weekStartsOn: 0, dailyTimeGoalH: 8, tabPinned: 'details', tabMode: 'pin',
+          periodLast: 'custom', dateFromLast: '2026-01-01', drillEntityLast: 'Work'
+        }));
+        expect(window.getSetting('theme')).toBe('dark');
+        expect(window.getSetting('palette')).toBe('colorblind');
+        expect(window.getSetting('refreshMs')).toBe(60000);
+        expect(window.getSetting('weekStartsOn')).toBe(0);
+        expect(window.getSetting('dailyTimeGoalH')).toBe(8);
+        expect(window.getSetting('tabPinned')).toBe('details');
+        // 'custom' is reachable from the Period control but is not a pinnable default
+        expect(window.getSetting('periodLast')).toBe('custom');
+        expect(window.getSetting('dateFromLast')).toBe('2026-01-01');
+        expect(window.getSetting('drillEntityLast')).toBe('Work');
+      });
+
+      it('rejects a malformed stored date without discarding the rest', () => {
+        window.importSettings(JSON.stringify({ dateFromLast: 'not-a-date', dateToLast: '2026-03-01' }));
+        expect(window.getSetting('dateFromLast')).toBe('');
+        expect(window.getSetting('dateToLast')).toBe('2026-03-01');
+      });
+
+      it('every enumerated setting offers exactly the values it will accept', () => {
+        // The UI and the validator must read from the same list.
+        const seen = new Set();
+        window.SETTINGS_SECTIONS.forEach(section => section.rows.forEach(row =>
+          row.controls.forEach(ctrl => {
+            if (!ctrl.key || !ctrl.options || ctrl.type === 'days' || ctrl.type === 'checks') return;
+            if (typeof window.DEFAULT_SETTINGS[ctrl.key] === 'boolean') return;
+            seen.add(ctrl.key);
+            ctrl.options.forEach(o => {
+              window.importSettings(JSON.stringify({ [ctrl.key]: o.v }));
+              expect(window.getSetting(ctrl.key), `${ctrl.key} should accept ${o.v}`).toBe(o.v);
+            });
+          })));
+        expect(seen.size).toBeGreaterThan(15);
+      });
+    });
+
     describe('General', () => {
       it('timeFormat switches formatTime between hours, decimal and minutes', () => {
         expect(window.formatTime(9000000)).toBe('2h 30m');


### PR DESCRIPTION
Three security fixes found by attacking `v1.6.0-rc`, plus an allowlist audit. Bumps to `1.6.0-rc.2`.

## 1. Settings values were type-checked but never value-checked

A well-typed string in the wrong place was enough to break the dashboard:

```
tabPinned: "evil"  →  pageerror: Cannot read properties of null (reading 'classList')
                      visible views: []
                      data ever loaded: 0h 0m
```

`switchTab('evil')` dereferenced null during init, aborting the rest of the script — including the bootstrap timer, so no data ever loaded. Recoverable only via Settings → Reset, which nobody would guess.

`coerceSetting` now validates the value: enums must name one of their options, numbers are clamped, array members filtered, exclusion lists capped, `*Last` keys validated (`tabLast` reaches `switchTab` the same way), stored dates must look like dates. `switchTab` also falls back rather than throwing.

`SETTING_OPTIONS` is now the single source for both the validator and the UI, so what a user can pick and what the validator accepts cannot drift. A test walks every control in the schema and imports each of its options.

## 2. CSV formula injection

`Copy text summary as → CSV` wrote names into cells verbatim, so `=cmd|'/c calc'!A1` executed on open in Excel or LibreOffice — the one path here that leaves the browser.

## 3. The iframe accepted `SP_STATE_CHANGED` from anyone

One unsolicited `postMessage` replaced the tag list:

```
before: ["+ Add…","Backend","Design","Frontend","Untagged"]
after:  ["+ Add…","ATTACKER-TAG-A","ATTACKER-TAG-B","Untagged"]
```

Neither `event.origin` nor `event.source` was checked. This is the mirror of #12 — v1.5.2 hardened `plugin.js` so the host verifies who is messaging it, but the iframe side never got the same treatment, which matters because anything sharing the host page (another installed plugin) can reach this frame. Impact is data poisoning, not execution; those names are escaped before they reach the DOM.

## Allowlist audit

Most guards were already allowlists. The one denylist was the CSV fix above, which enumerated `= + - @ tab CR`. Inverting it to "bare only if it opens with a letter or digit" immediately caught `|DDE`, an Excel DDE vector that was not on the list — demonstrated by mutation-testing the old rule.

Incoming tags are now rebuilt into a clean list rather than assigned wholesale, and export filenames drop leading dots and hyphens.

## Docs

`CLAUDE.md` still described the pre-hardening recipe for adding a setting, which skipped `SETTING_OPTIONS` — following it would have reproduced bug 1. Now four steps with validation as step two.

## Testing

**97 pass** (78 → 97). Two fixes were mutation-tested — reverted, confirmed the new test fails, restored — so neither passes vacuously.

Verified in Chromium against source and the minified build, including the `postMessage` fix in the real topology (dashboard in one iframe, hostile sibling in another: host post accepted, sibling rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)