### PR TITLE
feat: let users pick the plugin's sidebar icon

### DIFF
--- a/sp-dashboard/index.html
+++ b/sp-dashboard/index.html
@@ -374,6 +374,11 @@
     .set-chips-empty { font-size: 0.75rem; color: var(--text-color-muted, #9e9e9e); padding: 1px 4px; }
     .set-swatches { display: flex; gap: 3px; }
     .set-swatch { width: 14px; height: 14px; border-radius: 2px; }
+    .set-icons { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; width: 100%; }
+    .set-icon-btn { display: flex; align-items: center; justify-content: center; height: 34px; padding: 0; border: 1px solid var(--divider-color, #333); border-radius: 4px; background: none; color: var(--text-color-muted, #9e9e9e); cursor: pointer; }
+    .set-icon-btn:hover { border-color: var(--c-primary, #03a9f4); color: var(--text-color, #fff); }
+    .set-icon-btn.active { border-color: var(--c-primary, #03a9f4); color: var(--c-primary, #03a9f4); background: rgba(3, 169, 244, 0.12); }
+    .set-icon-btn svg { display: block; width: 20px; height: 20px; }
     .set-note { font-size: 0.7rem; color: var(--text-color-muted, #9e9e9e); }
     .set-btn { background: var(--bg, #121212); color: var(--text-color, #fff); border: 1px solid var(--divider-color, #333); border-radius: 4px; padding: 0.35rem 0.8rem; font-size: 0.8rem; cursor: pointer; }
     .set-btn:hover { border-color: var(--c-primary, #03a9f4); }
@@ -846,6 +851,7 @@
       density: 'comfortable',
       statCards: ['time', 'completed', 'overdue', 'late'],
       tablePageSize: 0,             // 0 = no limit
+      menuIcon: 'default',          // id from MENU_ICONS; 'default' keeps the manifest icon
 
       // --- Goals ---
       dailyTimeGoalOn: false, dailyTimeGoalH: 6,
@@ -885,6 +891,90 @@
     const MODE_OPTIONS = [sOpt('remember', 'Remember'), sOpt('pin', 'Pin')];
     const DIM_OPTIONS = [sOpt('project', 'Project'), sOpt('tag', 'Tag')];
 
+    // The icons offered by Settings › Appearance › Menu icon. Geometry, never
+    // markup: buildIconSvg() creates each node with createElementNS and copies
+    // only whitelisted attributes, so an entry here cannot become HTML or an
+    // event handler. The same allowlist shape the rest of this file uses.
+    //
+    // KEEP IN SYNC with MENU_ICONS in plugin.js, which applies the choice to
+    // the sidebar and needs the geometry before this iframe has ever loaded.
+    const MENU_ICONS = [
+      { id: 'default', label: 'Dashboard (default)', shapes: [
+        { t: 'rect', x: 3, y: 4, width: 18, height: 18, rx: 2 },
+        { t: 'line', x1: 8, y1: 2, x2: 8, y2: 6 },
+        { t: 'line', x1: 16, y1: 2, x2: 16, y2: 6 },
+        { t: 'line', x1: 3, y1: 10, x2: 21, y2: 10 },
+        { t: 'path', d: 'M6 19l4-3l4 2l4-5' }] },
+      { id: 'bars', label: 'Bar chart', shapes: [
+        { t: 'rect', x: 4, y: 12, width: 4, height: 8 },
+        { t: 'rect', x: 10, y: 7, width: 4, height: 13 },
+        { t: 'rect', x: 16, y: 3, width: 4, height: 17 },
+        { t: 'line', x1: 3, y1: 21, x2: 21, y2: 21 }] },
+      { id: 'pie', label: 'Pie chart', shapes: [
+        { t: 'circle', cx: 12, cy: 12, r: 9 },
+        { t: 'path', d: 'M12 12L12 3A9 9 0 0 1 21 12Z' }] },
+      { id: 'activity', label: 'Activity', shapes: [
+        { t: 'polyline', points: '3 12 7 12 10 4 14 20 17 12 21 12' }] },
+      { id: 'calendar', label: 'Calendar', shapes: [
+        { t: 'rect', x: 3, y: 4, width: 18, height: 18, rx: 2 },
+        { t: 'line', x1: 8, y1: 2, x2: 8, y2: 6 },
+        { t: 'line', x1: 16, y1: 2, x2: 16, y2: 6 },
+        { t: 'line', x1: 3, y1: 10, x2: 21, y2: 10 }] },
+      { id: 'clock', label: 'Clock', shapes: [
+        { t: 'circle', cx: 12, cy: 12, r: 9 },
+        { t: 'polyline', points: '12 7 12 12 16 14' }] },
+      { id: 'target', label: 'Target', shapes: [
+        { t: 'circle', cx: 12, cy: 12, r: 9 },
+        { t: 'circle', cx: 12, cy: 12, r: 5 },
+        { t: 'circle', cx: 12, cy: 12, r: 1.5, fill: 'currentColor' }] },
+      { id: 'grid', label: 'Grid', shapes: [
+        { t: 'rect', x: 3, y: 3, width: 7, height: 7, rx: 1 },
+        { t: 'rect', x: 14, y: 3, width: 7, height: 7, rx: 1 },
+        { t: 'rect', x: 14, y: 14, width: 7, height: 7, rx: 1 },
+        { t: 'rect', x: 3, y: 14, width: 7, height: 7, rx: 1 }] },
+      { id: 'trend', label: 'Trending up', shapes: [
+        { t: 'polyline', points: '3 17 9 11 13 15 21 7' },
+        { t: 'polyline', points: '15 7 21 7 21 13' }] },
+      { id: 'gauge', label: 'Gauge', shapes: [
+        { t: 'path', d: 'M4 19a9 9 0 1 1 16 0' },
+        { t: 'line', x1: 12, y1: 19, x2: 16, y2: 12 },
+        { t: 'circle', cx: 12, cy: 19, r: 1.5, fill: 'currentColor' }] }
+    ];
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const ICON_TAGS = ['rect', 'circle', 'line', 'path', 'polyline', 'polygon'];
+    const ICON_ATTRS = ['x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx', 'ry',
+                        'width', 'height', 'd', 'points'];
+
+    const getMenuIcon = (id) => MENU_ICONS.find(i => i.id === id) || MENU_ICONS[0];
+
+    const buildIconSvg = (def, size = 20) => {
+      const svg = document.createElementNS(SVG_NS, 'svg');
+      svg.setAttribute('viewBox', '0 0 24 24');
+      svg.setAttribute('width', String(size));
+      svg.setAttribute('height', String(size));
+      svg.setAttribute('fill', 'none');
+      svg.setAttribute('stroke', 'currentColor');
+      svg.setAttribute('stroke-width', '2');
+      svg.setAttribute('stroke-linecap', 'round');
+      svg.setAttribute('stroke-linejoin', 'round');
+      ((def && def.shapes) || []).forEach(shape => {
+        if (!shape || ICON_TAGS.indexOf(shape.t) === -1) return;
+        const node = document.createElementNS(SVG_NS, shape.t);
+        // fill is set per shape, not just on the <svg>: the host app's own
+        // stylesheet forces `fill: currentColor` onto the root, and a child with
+        // no fill of its own would inherit it and render as a solid blob.
+        const filled = shape.fill === 'currentColor';
+        node.setAttribute('fill', filled ? 'currentColor' : 'none');
+        if (filled) node.setAttribute('stroke', 'none');
+        ICON_ATTRS.forEach(attr => {
+          if (shape[attr] !== undefined) node.setAttribute(attr, String(shape[attr]));
+        });
+        svg.appendChild(node);
+      });
+      return svg;
+    };
+
     const SETTING_OPTIONS = {
       weekStartsOn: [sOpt(1, 'Monday'), sOpt(0, 'Sunday'), sOpt(6, 'Saturday')],
       dateFormat: [sOpt('auto', 'Auto (locale)'), sOpt('iso', 'ISO — 2026-02-22'),
@@ -918,7 +1008,8 @@
       tablePageSize: [sOpt(50, '50'), sOpt(100, '100'), sOpt(250, '250'), sOpt(0, 'All')],
       refreshMs: [sOpt(0, 'Off'), sOpt(10000, 'Every 10 seconds'), sOpt(30000, 'Every 30 seconds'),
                   sOpt(60000, 'Every minute'), sOpt(300000, 'Every 5 minutes')],
-      summaryFormat: [sOpt('slack', 'Slack'), sOpt('markdown', 'Markdown'), sOpt('csv', 'CSV')]
+      summaryFormat: [sOpt('slack', 'Slack'), sOpt('markdown', 'Markdown'), sOpt('csv', 'CSV')],
+      menuIcon: MENU_ICONS.map(i => sOpt(i.id, i.label))
     };
 
     // The `*Last` keys record what a dashboard control was last set to, so they
@@ -2644,7 +2735,9 @@
               sOpt('time', 'Total time tracked'), sOpt('completed', 'Tasks completed'),
               sOpt('overdue', 'Tasks overdue'), sOpt('late', 'Completed late')] }] },
           { label: 'Detailed List rows per page',
-            controls: [{ type: 'seg', key: 'tablePageSize', numeric: true, options: SETTING_OPTIONS.tablePageSize }] }
+            controls: [{ type: 'seg', key: 'tablePageSize', numeric: true, options: SETTING_OPTIONS.tablePageSize }] },
+          { label: 'Menu icon', hint: 'The icon on this plugin’s row in the app sidebar. Default keeps the icon the plugin ships with.',
+            controls: [{ type: 'icons', key: 'menuIcon', options: SETTING_OPTIONS.menuIcon }] }
         ]
       },
       {
@@ -2844,6 +2937,23 @@
         return wrap;
       }
 
+      if (ctrl.type === 'icons') {
+        const wrap = mkEl('div', 'set-icons');
+        ctrl.options.forEach(o => {
+          const on = current === o.v;
+          const btn = mkEl('button', 'set-icon-btn' + (on ? ' active' : ''));
+          btn.type = 'button';
+          btn.title = o.l;
+          btn.setAttribute('aria-label', o.l);
+          btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+          btn.dataset.key = ctrl.key;
+          btn.dataset.value = o.v;
+          btn.appendChild(buildIconSvg(getMenuIcon(o.v), 20));
+          wrap.appendChild(btn);
+        });
+        return wrap;
+      }
+
       if (ctrl.type === 'swatches') {
         const wrap = mkEl('div', 'set-swatches');
         getPalette().forEach(c => {
@@ -2943,11 +3053,27 @@
       }
     };
 
+    // The sidebar row lives in the host app, outside this iframe, so all we can
+    // do about it is say which icon was picked. plugin.js performs the swap, and
+    // reads the same stored setting itself at startup, so the row is already
+    // right before the dashboard has ever been opened.
+    const pushMenuIcon = () => {
+      if (!window.parent || window.parent === window) return;
+      const def = getMenuIcon(getSetting('menuIcon'));
+      try {
+        window.parent.postMessage(
+          { type: 'SP_DASHBOARD_SET_MENU_ICON', iconId: def.id, shapes: def.shapes }, '*');
+      } catch (e) {
+        debugWarn('[sp-dashboard] could not push the menu icon to the host', e);
+      }
+    };
+
     // Re-derive everything a setting could have changed. Cheap enough to run on
     // every edit, which is what lets the modal have no Save button.
     const applySettings = ({ reprocess = true } = {}) => {
       applyAppearance();
       restartLiveUpdate();
+      pushMenuIcon();
       currentSort = { key: getSetting('sortKey'), dir: getSetting('sortDir') };
       if (reprocess) processData(cachedTasks, cachedProjects, cachedTags);
       renderSettingsPanel();
@@ -3124,11 +3250,13 @@
     // Opening tab (Settings › Defaults)
     switchTab(resolveDefault('tabMode', 'tabPinned', 'tabLast'));
     applyAppearance();
+    pushMenuIcon();
 
     // expose key utilities for testing (JSDOM environment won't execute script tags normally)
     window.DEFAULT_SETTINGS = DEFAULT_SETTINGS;
     window.SETTINGS_KEY = SETTINGS_KEY;
     window.SETTINGS_SECTIONS = SETTINGS_SECTIONS;
+    window.MENU_ICONS = MENU_ICONS;
     window.getSetting = getSetting;
     window.setSetting = setSetting;
     window.getAllSettings = () => SETTINGS;

--- a/sp-dashboard/plugin.js
+++ b/sp-dashboard/plugin.js
@@ -51,6 +51,198 @@ window.addEventListener('message', (event) => {
   }
 });
 
+// ==========================================================
+// MENU ICON (Settings > Appearance > Menu icon)
+// Super Productivity draws a plugin's sidebar row from the SVG in its
+// manifest and offers no API for changing it afterwards, so the user's
+// choice is applied by replacing the rendered node. Two things make that
+// safe rather than a blind DOM hack:
+//   - the row carries `data-plugin-id`, so we only ever touch our own;
+//   - the node we replace is `div.plugin-svg-icon`, the host's own
+//     container for a plugin-supplied icon, not app chrome.
+// The original children are stashed before the first swap, so picking
+// "Dashboard (default)" restores the manifest icon exactly.
+//
+// The setting itself is written by the dashboard iframe. Its localStorage
+// is this window's localStorage (the iframe is `srcdoc` + allow-same-origin),
+// so the icon can be applied at startup, before the dashboard has ever been
+// opened. Live changes arrive as SP_DASHBOARD_SET_MENU_ICON.
+//
+// KEEP IN SYNC with MENU_ICONS in index.html, which draws the pickers from
+// the same geometry.
+// ==========================================================
+const SETTINGS_KEY = 'sp-dashboard-settings';
+const DEFAULT_ICON_ID = 'default';
+
+const MENU_ICONS = [
+  { id: 'default', label: 'Dashboard (default)', shapes: [
+    { t: 'rect', x: 3, y: 4, width: 18, height: 18, rx: 2 },
+    { t: 'line', x1: 8, y1: 2, x2: 8, y2: 6 },
+    { t: 'line', x1: 16, y1: 2, x2: 16, y2: 6 },
+    { t: 'line', x1: 3, y1: 10, x2: 21, y2: 10 },
+    { t: 'path', d: 'M6 19l4-3l4 2l4-5' }] },
+  { id: 'bars', label: 'Bar chart', shapes: [
+    { t: 'rect', x: 4, y: 12, width: 4, height: 8 },
+    { t: 'rect', x: 10, y: 7, width: 4, height: 13 },
+    { t: 'rect', x: 16, y: 3, width: 4, height: 17 },
+    { t: 'line', x1: 3, y1: 21, x2: 21, y2: 21 }] },
+  { id: 'pie', label: 'Pie chart', shapes: [
+    { t: 'circle', cx: 12, cy: 12, r: 9 },
+    { t: 'path', d: 'M12 12L12 3A9 9 0 0 1 21 12Z' }] },
+  { id: 'activity', label: 'Activity', shapes: [
+    { t: 'polyline', points: '3 12 7 12 10 4 14 20 17 12 21 12' }] },
+  { id: 'calendar', label: 'Calendar', shapes: [
+    { t: 'rect', x: 3, y: 4, width: 18, height: 18, rx: 2 },
+    { t: 'line', x1: 8, y1: 2, x2: 8, y2: 6 },
+    { t: 'line', x1: 16, y1: 2, x2: 16, y2: 6 },
+    { t: 'line', x1: 3, y1: 10, x2: 21, y2: 10 }] },
+  { id: 'clock', label: 'Clock', shapes: [
+    { t: 'circle', cx: 12, cy: 12, r: 9 },
+    { t: 'polyline', points: '12 7 12 12 16 14' }] },
+  { id: 'target', label: 'Target', shapes: [
+    { t: 'circle', cx: 12, cy: 12, r: 9 },
+    { t: 'circle', cx: 12, cy: 12, r: 5 },
+    { t: 'circle', cx: 12, cy: 12, r: 1.5, fill: 'currentColor' }] },
+  { id: 'grid', label: 'Grid', shapes: [
+    { t: 'rect', x: 3, y: 3, width: 7, height: 7, rx: 1 },
+    { t: 'rect', x: 14, y: 3, width: 7, height: 7, rx: 1 },
+    { t: 'rect', x: 14, y: 14, width: 7, height: 7, rx: 1 },
+    { t: 'rect', x: 3, y: 14, width: 7, height: 7, rx: 1 }] },
+  { id: 'trend', label: 'Trending up', shapes: [
+    { t: 'polyline', points: '3 17 9 11 13 15 21 7' },
+    { t: 'polyline', points: '15 7 21 7 21 13' }] },
+  { id: 'gauge', label: 'Gauge', shapes: [
+    { t: 'path', d: 'M4 19a9 9 0 1 1 16 0' },
+    { t: 'line', x1: 12, y1: 19, x2: 16, y2: 12 },
+    { t: 'circle', cx: 12, cy: 19, r: 1.5, fill: 'currentColor' }] }
+];
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const ICON_TAGS = ['rect', 'circle', 'line', 'path', 'polyline', 'polygon'];
+const ICON_ATTRS = ['x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx', 'ry',
+                    'width', 'height', 'd', 'points'];
+
+// Nodes are built with createElementNS and only whitelisted attributes are
+// copied across, so nothing that arrives here can turn into markup or an
+// event handler -- the shapes are geometry or they are dropped.
+function buildIconSvg(shapes) {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('width', '24');
+  svg.setAttribute('height', '24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  (Array.isArray(shapes) ? shapes : []).forEach((shape) => {
+    if (!shape || ICON_TAGS.indexOf(shape.t) === -1) return;
+    const node = document.createElementNS(SVG_NS, shape.t);
+    // The host stylesheet forces `fill: currentColor` onto the <svg>; a child
+    // without its own fill would inherit it and render as a solid blob.
+    const filled = shape.fill === 'currentColor';
+    node.setAttribute('fill', filled ? 'currentColor' : 'none');
+    if (filled) node.setAttribute('stroke', 'none');
+    ICON_ATTRS.forEach((attr) => {
+      if (shape[attr] !== undefined) node.setAttribute(attr, String(shape[attr]));
+    });
+    svg.appendChild(node);
+  });
+  return svg;
+}
+
+function findMenuIcon(id) {
+  return MENU_ICONS.find((i) => i.id === id) || MENU_ICONS[0];
+}
+
+// The iframe owns the settings blob; we only ever read it, and only this key.
+function readStoredIconId() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return DEFAULT_ICON_ID;
+    const parsed = JSON.parse(raw);
+    const id = parsed && parsed.menuIcon;
+    return typeof id === 'string' && MENU_ICONS.some((i) => i.id === id)
+      ? id
+      : DEFAULT_ICON_ID;
+  } catch (e) {
+    return DEFAULT_ICON_ID;
+  }
+}
+
+let currentIconId = readStoredIconId();
+let currentIconShapes = findMenuIcon(currentIconId).shapes;
+const originalIconNodes = new WeakMap();
+
+function applyMenuIcon() {
+  const hosts = document.querySelectorAll(
+    'nav-item[data-plugin-id="' + PLUGIN_ID + '"] .plugin-svg-icon'
+  );
+  hosts.forEach((host) => {
+    // Already showing this icon -- nothing to do. This is what keeps the
+    // MutationObserver below from turning every nav repaint into DOM work.
+    if (host.dataset.spDashboardIcon === currentIconId) return;
+    // Nothing has been swapped on this node and the manifest icon is what we
+    // want anyway, so leave the host's own DOM untouched. Anyone who never
+    // opens this setting keeps exactly the markup the app rendered.
+    if (currentIconId === DEFAULT_ICON_ID && !originalIconNodes.has(host)) return;
+    if (!originalIconNodes.has(host)) {
+      originalIconNodes.set(host, Array.from(host.childNodes, (n) => n.cloneNode(true)));
+    }
+    if (currentIconId === DEFAULT_ICON_ID) {
+      host.replaceChildren(...originalIconNodes.get(host).map((n) => n.cloneNode(true)));
+    } else {
+      host.replaceChildren(buildIconSvg(currentIconShapes));
+    }
+    host.dataset.spDashboardIcon = currentIconId;
+  });
+}
+
+// Angular recreates the sidebar row whenever the nav re-renders (collapse,
+// route change, a project being added), which throws our node away. Re-apply
+// after the fact rather than fighting change detection. Coalesced into one
+// pass per frame so a busy app doesn't pay for it.
+let iconPassQueued = false;
+function scheduleMenuIcon() {
+  if (iconPassQueued) return;
+  iconPassQueued = true;
+  const run = () => {
+    iconPassQueued = false;
+    applyMenuIcon();
+  };
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run);
+  else setTimeout(run, 0);
+}
+
+try {
+  new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.addedNodes.length || record.removedNodes.length) {
+        scheduleMenuIcon();
+        return;
+      }
+    }
+  }).observe(document.body, { childList: true, subtree: true });
+} catch (e) {
+  console.warn("[sp-dashboard plugin] could not watch the sidebar for re-renders", e);
+}
+
+scheduleMenuIcon();
+
+// Live updates from Settings > Appearance. Same ownership check as the
+// download bridge: only our own iframe may retarget our own row.
+window.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || data.type !== 'SP_DASHBOARD_SET_MENU_ICON') return;
+  if (!isOwnPluginWindow(event.source)) return;
+  const id = typeof data.iconId === 'string' ? data.iconId : DEFAULT_ICON_ID;
+  currentIconId = MENU_ICONS.some((i) => i.id === id) ? id : DEFAULT_ICON_ID;
+  currentIconShapes = Array.isArray(data.shapes)
+    ? data.shapes
+    : findMenuIcon(currentIconId).shapes;
+  applyMenuIcon();
+});
+
 // We listen to the global Redux ACTION hook.
 // Whenever the user adds a task, tracks time, or changes a project, this fires.
 PluginAPI.registerHook(PluginAPI.Hooks.ACTION, async (action) => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1296,6 +1296,23 @@ describe('Date Range Reporter UI', () => {
         expect(rows[2].textContent).toContain('Showing 2 of 3');
       });
 
+      it('menuIcon defaults to the manifest icon and switches on click', () => {
+        expect(window.getSetting('menuIcon')).toBe('default');
+
+        window.openSettings();
+        document.getElementById('settings-rail').querySelector('[data-section="appearance"]')
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        const buttons = document.querySelectorAll('.set-icons .set-icon-btn');
+        expect([...buttons].map(b => b.dataset.value)).toEqual(window.MENU_ICONS.map(i => i.id));
+
+        // In real use the click lands on the preview svg, not the button.
+        document.querySelector('.set-icon-btn[data-value="clock"] svg')
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(window.getSetting('menuIcon')).toBe('clock');
+        expect(document.querySelector('.set-icon-btn.active').dataset.value).toBe('clock');
+      });
+
       it('theme puts an explicit override class on the body', () => {
         window.setSetting('theme', 'light');
         expect(document.body.classList.contains('force-light')).toBe(true);


### PR DESCRIPTION
## What

A **Menu icon** row in Settings › Appearance: ten built-in icons, plus *Dashboard (default)* which keeps the icon the plugin ships with. Nothing changes for anyone who doesn't go looking for it.

## Why

Speaking as someone who makes Super Productivity themes — this is exactly the kind of opt-in we like to see from plugins. A theme sets the tone of the whole sidebar, and one plugin icon that doesn't match the icon set is the thing that stands out. Letting the user pick keeps that choice with the person who can actually see the result, instead of the plugin author picking one for everybody or a theme having to fight it with CSS. And because the default is untouched, nobody who doesn't care ever notices.

## How

The host renders a plugin's nav icon from `manifest.json` and offers no API for changing it afterwards, so `plugin.js` swaps the rendered node:

- **Only its own row.** `nav-item[data-plugin-id="sp-dashboard"] .plugin-svg-icon` — never another plugin's entry, never app chrome. It replaces the host's own container for a plugin-supplied icon, nothing else.
- **Icons are geometry, not markup.** `MENU_ICONS` is a list of shape descriptors; `buildIconSvg()` creates each node with `createElementNS` and copies only allowlisted tags and attributes, so nothing on this path can become HTML or an event handler. Same allowlist-not-denylist shape as #15.
- **Applied before the iframe has ever loaded.** `plugin.js` reads `menuIcon` out of `localStorage` at startup (the iframe is `srcdoc` + `allow-same-origin`, so it shares this window's storage), and listens for `SP_DASHBOARD_SET_MENU_ICON` for live changes — behind the existing `isOwnPluginWindow` sender check.
- **Survives nav re-renders.** Angular rebuilds the sidebar row on collapse / route change / a project being added, which throws our node away; a debounced `MutationObserver` re-applies rather than fighting change detection.
- **`'default'` is genuinely inert.** A row that was never swapped is left completely untouched, and picking default again restores the original children, stashed before the first swap.

`menuIcon` is registered in `SETTING_OPTIONS`, so the existing *"every enumerated setting offers exactly the values it will accept"* test covers it automatically. 98 tests pass.

## Two things worth flagging

- `MENU_ICONS` is duplicated between `index.html` (which draws the pickers) and `plugin.js` (which needs the geometry before the iframe exists). Both carry a KEEP IN SYNC comment. Happy to replace this with a build-time inject in `make build`, or a drift test, if you'd prefer one over the other — I didn't want to change the build pipeline unasked.
- Unrelated heads-up: `npm test` doesn't run at all for me on Node 26 — vitest 1.6.1's jsdom environment doesn't expose `localStorage` as a global, so all tests die on `localStorage.clear()` in `beforeEach` before any plugin code loads. I verified this branch with a temporary setup-file shim. Probably worth a vitest bump in its own PR.
